### PR TITLE
validations prevent non-member filesets being saved as thumbnail or representative

### DIFF
--- a/app/models/generic_work.rb
+++ b/app/models/generic_work.rb
@@ -12,4 +12,26 @@ class GenericWork < ActiveFedora::Base
   # self.valid_child_concerns = []
   validates :title, presence: { message: 'Your work must have a title.' }
 
+  validate :legal_representative_id, :legal_thumbnail_id
+
+  protected
+
+  def legal_representative_id
+    return if representative_id.nil?
+    # This is known to cause problems with curation_concerns@608b02916cd7,
+    # doesn't make sense to have a representative that's not in members.
+    # But happened at least once anyway. Try to prevent it.
+    unless ordered_member_ids.include?(representative_id) && member_ids.include?(representative_id)
+      errors.add(:representative_id, "must be included in members and ordered_members")
+    end
+  end
+
+  def legal_thumbnail_id
+    return if thumbnail_id.nil?
+    # While this is NOT known to cause problems with curation_concerns@608b02916cd7,
+    # it does seem to violate the intentional semantics, so we'll prevent it.
+    unless ordered_member_ids.include?(thumbnail_id) && member_ids.include?(thumbnail_id)
+      errors.add(:thumbnail_id, "must be included in members and ordered_members")
+    end
+  end
 end

--- a/spec/models/generic_work_spec.rb
+++ b/spec/models/generic_work_spec.rb
@@ -125,5 +125,24 @@ RSpec.describe GenericWork do
       end
     end
 
+    describe "illegal representative_id" do
+      before do
+        gf.representative = FactoryGirl.create(:file_set)
+      end
+      it "is not valid" do
+        expect(gf.save).to be(false)
+        expect(gf.errors.messages.keys).to include(:representative_id)
+      end
+    end
+
+    describe "illegal thumbnail_id" do
+      before do
+        gf.thumbnail = FactoryGirl.create(:file_set)
+      end
+      it "is not valid" do
+        expect(gf.save).to be(false)
+        expect(gf.errors.messages.keys).to include(:thumbnail_id)
+      end
+    end
   end
 end


### PR DESCRIPTION
In the case of representative, known to mess up display logic in bad ways, see #394.
In case of thumbnail, just a precaution, enforce what I think are intended semantics.

After spending a couple hours on it, I was not able to find any reasonable
solution to fixing the front-end logic to not infinite loop on this kind
of bad data. The validations should prevent it, not reasonable at this
time to do the other checkbox there. 

Closes #394