### PR TITLE
Better mass index

### DIFF
--- a/lib/chf/indexer.rb
+++ b/lib/chf/indexer.rb
@@ -1,0 +1,60 @@
+module CHF
+
+  # This code in ActiveFedora master but not yet released, we shouldn't need
+  # a custom indexing routine once it is, can just use ActiveFedora::Base.reindex_everything
+  #
+  # https://github.com/projecthydra/active_fedora/pull/1219
+  # https://github.com/projecthydra/active_fedora/pull/1218
+  if Gem.loaded_specs["active-fedora"].version >= Gem::Version.new('11.2')
+     msg = "\n\nPlease check and make sure this patch is still needed at #{__FILE__}:#{__LINE__}\n\n"
+     $stderr.puts msg
+     Rails.logger.warn msg
+  end
+
+  # A custom fedora-to-solr indexer that uses code submitted to ActiveFedora
+  # but not yet released.
+  class Indexer
+    def reindex_everything(batch_size: 50, softCommit: true, progress_bar: false, final_commit: false)
+      s_time = Time.now.localtime
+      $stderr.puts "fetching all URIs from fedora at #{s_time}, might take 20+ minutes?..."
+      descendants = descendant_uris(ActiveFedora.fedora.base_uri)
+      $stderr.puts "fetched all URIs from fedora at #{Time.now.localtime} in: #{(Time.mktime(0)+(Time.now.localtime - s_time)).strftime("%H:%M:%S")}"
+
+
+      batch = []
+
+      progress_bar_controller = ProgressBar.create(total: descendants.count, format: "%t: |%B| %p%% %e") if progress_bar
+
+      descendants.each do |uri|
+        # skip root url
+        next if uri == ActiveFedora.fedora.base_uri
+
+        Rails.logger.debug "Re-index everything ... #{uri}"
+        batch << ActiveFedora::Base.find(ActiveFedora::Base.uri_to_id(uri)).to_solr
+        if (batch.count % batch_size).zero?
+          ActiveFedora::SolrService.add(batch, softCommit: softCommit)
+          batch.clear
+        end
+
+        progress_bar_controller.increment if progress_bar_controller
+      end
+
+      if batch.present?
+        ActiveFedora::SolrService.add(batch, softCommit: softCommit)
+        batch.clear
+      end
+
+      progress_bar_controller.finish
+
+      if final_commit
+        $stderr.puts "Solr hard commit at #{Time.now.localtime}..."
+        ActiveFedora::SolrService.commit
+      end
+      $stderr.puts "chf:index complete at #{Time.now.localtime}"
+    end
+
+    def descendant_uris(uri)
+      DescendantFetcher.new(uri).descendant_and_self_uris
+    end
+  end
+end

--- a/lib/chf/indexer/descendant_fetcher.rb
+++ b/lib/chf/indexer/descendant_fetcher.rb
@@ -1,0 +1,112 @@
+module CHF
+  class Indexer
+
+    # This code in ActiveFedora master but not yet released, we shouldn't need
+    # a custom indexing routine once it is, can just use ActiveFedora::Base.reindex_everything
+    #
+    # https://github.com/projecthydra/active_fedora/pull/1219
+    # https://github.com/projecthydra/active_fedora/pull/1218
+    if Gem.loaded_specs["active-fedora"].version >= Gem::Version.new('11.2')
+       msg = "\n\nPlease check and make sure this patch is still needed at #{__FILE__}:#{__LINE__}\n\n"
+       $stderr.puts msg
+       Rails.logger.warn msg
+    end
+
+    # Finds all descendent URIs of a given repo URI (usually the base URI).
+    #
+    # This is a slow and non-performant thing to do, we need to fetch every single
+    # object from the repo.
+    #
+    # The DescendantFetcher is also capable of partitioning the URIs into "priority" URIs
+    # that will be first in the returned list. These prioritized URIs belong to objects
+    # with certain hasModel models. This feature is used in some hydra apps that need to
+    # index 'permissions' objects before other objects to have the solr indexing work right.
+    # And so by default, the prioritized class names are the ones form Hydra::AccessControls,
+    # but you can alter the prioritized model name list, or set it to the empty array.
+    #
+    #     DescendantFetcher.new(ActiveFedora.fedora.base_uri).descendent_and_self_uris
+    #     #=> array including self uri and descendent uris with "prioritized" (by default)
+    #         Hydra::AccessControls permissions) objects FIRST.
+    #
+    # Change the default prioritized hasModel names:
+    #
+    #     ActiveFedora::Indexing::DescendantFetcher.default_priority_models = []
+    class DescendantFetcher
+      HAS_MODEL_PREDICATE = ActiveFedora::RDF::Fcrepo::Model.hasModel
+
+      class_attribute :default_priority_models, instance_accessor: false
+      self.default_priority_models = %w(Hydra::AccessControl Hydra::AccessControl::Permissions).freeze
+
+      attr_reader :uri, :priority_models
+
+      def initialize(uri,
+                     priority_models: self.class.default_priority_models)
+        @uri = uri
+        @priority_models = priority_models
+      end
+
+      def descendant_and_self_uris
+        partitioned = descendant_and_self_uris_partitioned
+        partitioned[:priority] + partitioned[:other]
+      end
+
+      # returns a hash where key :priority is an array of all prioritized
+      # type objects, key :other is an array of the rest.
+      def descendant_and_self_uris_partitioned
+        resource = Ldp::Resource::RdfSource.new(ActiveFedora.fedora.connection, uri)
+        # GET could be slow if it's a big resource, we're using HEAD to avoid this problem,
+        # but this causes more requests to Fedora.
+        return partitioned_uris unless resource.head.rdf_source?
+
+        add_self_to_partitioned_uris
+
+        immediate_descendant_uris = rdf_graph.query(predicate: ::RDF::Vocab::LDP.contains).map { |descendant| descendant.object.to_s }
+        immediate_descendant_uris.each do |descendant_uri|
+          self.class.new(
+            descendant_uri,
+            priority_models: priority_models
+          ).descendant_and_self_uris_partitioned.tap do |descendant_partitioned|
+            partitioned_uris[:priority].concat descendant_partitioned[:priority]
+            partitioned_uris[:other].concat descendant_partitioned[:other]
+          end
+        end
+        partitioned_uris
+      end
+
+      protected
+
+        def rdf_resource
+          @rdf_resource ||= Ldp::Resource::RdfSource.new(ActiveFedora.fedora.connection, uri)
+        end
+
+        def rdf_graph
+          @rdf_graph ||= rdf_resource.graph
+        end
+
+        def partitioned_uris
+          @partitioned_uris ||= {
+            priority: [],
+            other: []
+          }
+        end
+
+        def rdf_graph_models
+          rdf_graph.query(predicate: HAS_MODEL_PREDICATE).collect(&:object).collect do |rdf_object|
+            rdf_object.to_s if rdf_object.literal?
+          end.compact
+        end
+
+        def prioritized_object?
+          priority_models.present? && (rdf_graph_models & priority_models).count > 0
+        end
+
+        def add_self_to_partitioned_uris
+          if prioritized_object?
+            partitioned_uris[:priority] << rdf_resource.subject
+          else
+            partitioned_uris[:other] << rdf_resource.subject
+          end
+        end
+    end
+  end
+end

--- a/lib/tasks/chf_tasks.rake
+++ b/lib/tasks/chf_tasks.rake
@@ -39,8 +39,7 @@ namespace :chf do
 
   desc 'Reindex everything'
   task reindex: :environment do
-    ActiveFedora::Base.reindex_everything
-    puts 'reindex complete'
+    CHF::Indexer.new.reindex_everything(progress_bar: true, final_commit: true)
   end
 
   desc 'report translated titles'


### PR DESCRIPTION
* Uses batch and progress bar.
* Indexes permissions objects first, should eliminate double-index need

Based on code already in active-fedora master.

Closes #348

@hackmaster.a I'm not sure how to test to confirm it eliminates need
for double-index. Do you want to do that, or tell me how (what the
problem case looked like before)?