### PR TITLE
Remove file hint

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -28,6 +28,8 @@ en:
         date_of_work: "Date"
         description: "Description"
     hints:
+      defaults:
+        files: '' # no file hint for now
       generic_work:
         title: "Use a given title if available; otherwise, construct a brief descriptive title that uniquely identifies the work. Use title case (ex: \"The Quick Brown Fox Jumps Over the Lazy Dog\") for formal and published titles and sentence case (ex: \"The quick brown fox jumps over the lazy dog\") for constructed and supplied titles. Required to save."
         additional_title: "Use for additional or varying form of title if it contributes to further identification of the work. Subtitles or translated titles can be recorded here (without brackets)."


### PR DESCRIPTION
Formerly "A PDF is preferred"

Closes #286

I was not able to actually find where the upload a new version is in
the UX, although I know I found it last week! So have not confirmed, but
pretty sure this will remove the prompt.