### PR TITLE
Solve "Single and Batch Work upload forms too similar in Sufia 7" closes #261

### DIFF
--- a/app/assets/stylesheets/local/upload_works.scss
+++ b/app/assets/stylesheets/local/upload_works.scss
@@ -1,0 +1,3 @@
+.new_batch_upload_item .instructions {
+  @extend .alert, .alert-info;
+}

--- a/app/views/curation_concerns/base/new.html.erb
+++ b/app/views/curation_concerns/base/new.html.erb
@@ -1,0 +1,8 @@
+<% provide :page_title, curation_concern_page_title(curation_concern) %>
+<% provide :page_header do %>
+  <h1><%= t("controllers.#{controller_name}.#{action_name}.header",
+             scope: "sufia.works",
+             default: :"#{action_name}.header") %></h1>
+<% end %>
+
+<%= render 'form' %>

--- a/config/locales/sufia.en.yml
+++ b/config/locales/sufia.en.yml
@@ -12,3 +12,8 @@ en:
       suffix:           "@chemheritage.org"
     footer:
       copyright_html: "<strong>Copyright &copy; 2016 Project Hydra</strong> Licensed under the Apache License, Version 2.0"
+    works:
+      controllers:
+        batch_uploads:
+          new:
+            header: Add Batch of Multiple New Works


### PR DESCRIPTION
1) Different title for single vs batch work upload form. Not sure if there's a better way to organize the i18n keys, this seemed clever to me, or might be too confusing.

2) put batch upload files instructions in alert style to further differentiate batch from single work upload