### PR TITLE
Add configuration for working_path

### DIFF
--- a/config/initializers/curation_concerns.rb
+++ b/config/initializers/curation_concerns.rb
@@ -1,0 +1,6 @@
+CurationConcerns.configure do |config|
+  # Location on local file system where uploaded files will be staged
+  # prior to being ingested into the repository or having derivatives generated.
+  # If you use a multi-server architecture, this MUST be a shared volume.
+  config.working_path = Rails.env.production? ? '/tmp/working' : (ENV['SUFIA_TMP_PATH'] || '/tmp')
+end


### PR DESCRIPTION
This location used as a holding area for files pulled from fedora for
derivatives generation. Generally not needed during ingest, since the
files are taken from their upload location (managed by CarrierWave).

Sufia made an effort at one point to make sure all CC config values were
managed by Sufia's config, as well, but this one must have slipped
through the cracks. Hence it's in a new CC initializer.