### PR TITLE
Cap fix

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -55,7 +55,7 @@ end
 group :development do
   gem 'capistrano', '3.4.0'
   gem 'capistrano-bundler', '1.1.4'
-  gem 'capistrano-passenger', '0.1.0'
+  gem 'capistrano-passenger', '0.2.0'
   gem 'capistrano-rails', '1.1.3'
   gem 'capistrano-maintenance', '~> 1.0', require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -146,7 +146,7 @@ GEM
       sshkit (~> 1.2)
     capistrano-maintenance (1.0.0)
       capistrano (>= 3.0)
-    capistrano-passenger (0.1.0)
+    capistrano-passenger (0.2.0)
       capistrano (~> 3.0)
     capistrano-rails (1.1.3)
       capistrano (~> 3.1)
@@ -795,7 +795,7 @@ DEPENDENCIES
   capistrano (= 3.4.0)
   capistrano-bundler (= 1.1.4)
   capistrano-maintenance (~> 1.0)
-  capistrano-passenger (= 0.1.0)
+  capistrano-passenger (= 0.2.0)
   capistrano-rails (= 1.1.3)
   capybara (~> 2.4)
   capybara-screenshot

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -12,8 +12,8 @@ set :keep_releases, 5
 # label deploys with server local time instead of utm
 set :deploytag_utc, false
 
-# using 'touch tmp/restart.txt to restart passenger
-set :passenger_restart_with_touch, true
+# use 'passenger-config restart-app' to restart passenger
+set :passenger_restart_with_touch, false
 
 # send some data to whenever
 set :whenever_identifier, ->{ "#{fetch(:application)}_#{fetch(:stage)}" }


### PR DESCRIPTION
It looked like capistrano wasn't correctly restarting our app on deploy. Update to a newer deploy strategy; upgrade the gem while we're at it. Although the gem hasn't been touched in a while; is it possible it's no longer maintaned? Has everyone switched to puma?