### PR TITLE
Start of SyntheticCategories

### DIFF
--- a/app/models/search_builder.rb
+++ b/app/models/search_builder.rb
@@ -12,5 +12,7 @@ class SearchBuilder < Blacklight::SearchBuilder
 
   include Hydra::AccessControlsEnforcement
   include CurationConcerns::SearchFilters
+
   include SearchBuilder::RestrictAdminSearchFields
+  include SearchBuilder::SyntheticCategoryLimit
 end

--- a/app/models/search_builder/synthetic_category_limit.rb
+++ b/app/models/search_builder/synthetic_category_limit.rb
@@ -17,9 +17,9 @@ class SearchBuilder
   #
   # Now when you do things with that search builder, it's locked to :portraits_and_people
   #
-  #     synthetic_category_param : set to a string, and this will be taken
-  #       from app params to identify a collection to limit to.  If unknown,
-  #       will do nothing. (Should limit to 0 rows instead?)
+  #     synthetic_category_param : set to a symbol, and this will be taken
+  #       from app params to identify a collection to limit to.  If a string
+  #        not matching a category is provided, will limit to 0 results, beware!
   #     synthetic_category_force: symbol of synthetic collection key,
   #       will just force limiting to there.
   module SyntheticCategoryLimit

--- a/app/models/search_builder/synthetic_category_limit.rb
+++ b/app/models/search_builder/synthetic_category_limit.rb
@@ -29,6 +29,11 @@ class SearchBuilder
       if synthetic_category
         solr_params[:fq] ||= []
         solr_params[:fq] << synthetic_category.solr_fq
+      elsif synthetic_category_param.present?
+        # trying to use param mapping for a category that doesn't exist, let's give you zero
+        # results!
+        solr_params[:fq] ||= []
+        solr_params[:fq] << "-*:*"
       end
 
     end

--- a/app/models/search_builder/synthetic_category_limit.rb
+++ b/app/models/search_builder/synthetic_category_limit.rb
@@ -1,0 +1,37 @@
+class SearchBuilder
+  # A search builder module to restrict to a certain SyntheticCollection.
+  # Won't do _anything_ just by being in the chain -- sets class_attributes
+  # on the SearchBuilder that can be used to turn it 'on', either on the class
+  # or even on an instance.
+  #
+  #.    synthetic_category_param : set to a string, and this will be taken
+  #.      from app params to identify a collection to limit to.  If unknown,
+  #.      will do nothing. (Should limit to 0 rows instead?)
+  #.    synthetic_category_force: symbol of synthetic collection key,
+  #.      will just force limiting to there.
+  module SyntheticCategoryLimit
+    extend ActiveSupport::Concern
+
+    included do
+      self.default_processor_chain += [:synthetic_collection_limit]
+      class_attribute :synthetic_category_param
+      class_attribute :synthetic_category_force
+    end
+
+
+    def synthetic_collection_limit(solr_params)
+      synthetic_category = if synthetic_category_force.present?
+        CHF::SyntheticCategory.new(synthetic_category_force)
+      elsif synthetic_category_param.present? && CHF::SyntheticCategory.has_key?(blacklight_params[synthetic_category_param])
+        CHF::SyntheticCategory.new(blacklight_params[synthetic_category_param])
+      end
+
+      if synthetic_category
+        solr_params[:fq] ||= []
+        solr_params[:fq] << synthetic_category.solr_fq
+      end
+
+    end
+
+  end
+end

--- a/app/models/search_builder/synthetic_category_limit.rb
+++ b/app/models/search_builder/synthetic_category_limit.rb
@@ -1,14 +1,27 @@
 class SearchBuilder
   # A search builder module to restrict to a certain SyntheticCollection.
-  # Won't do _anything_ just by being in the chain -- sets class_attributes
-  # on the SearchBuilder that can be used to turn it 'on', either on the class
-  # or even on an instance.
   #
-  #.    synthetic_category_param : set to a string, and this will be taken
-  #.      from app params to identify a collection to limit to.  If unknown,
-  #.      will do nothing. (Should limit to 0 rows instead?)
-  #.    synthetic_category_force: symbol of synthetic collection key,
-  #.      will just force limiting to there.
+  # This module doesn't do anything just by being included, it needs one
+  # of synthetic_category_param or synthetic_category_force to be set -- on
+  # either the class or the instance.
+  #
+  # synthetic_category_param sets a key to take from the app query params
+  # to map to a collection. You might set it on a class, with:
+  #
+  #      SearchBuilder.synthetic_category_param = :category
+  #
+  # synthetic_category_force forces to a specific category, you might
+  # set it on a particular search_builder instance:
+  #
+  #      some_search_builder.tap { |sb| sb.synthetic_category_force = :portraits_and_people }.search(...)
+  #
+  # Now when you do things with that search builder, it's locked to :portraits_and_people
+  #
+  #     synthetic_category_param : set to a string, and this will be taken
+  #       from app params to identify a collection to limit to.  If unknown,
+  #       will do nothing. (Should limit to 0 rows instead?)
+  #     synthetic_category_force: symbol of synthetic collection key,
+  #       will just force limiting to there.
   module SyntheticCategoryLimit
     extend ActiveSupport::Concern
 

--- a/app/models/search_builder/synthetic_category_limit.rb
+++ b/app/models/search_builder/synthetic_category_limit.rb
@@ -42,7 +42,7 @@ class SearchBuilder
       if synthetic_category
         solr_params[:fq] ||= []
         solr_params[:fq] << synthetic_category.solr_fq
-      elsif synthetic_category_param.present?
+      elsif synthetic_category_param.present? && blacklight_params[synthetic_category_param].present?
         # trying to use param mapping for a category that doesn't exist, let's give you zero
         # results!
         solr_params[:fq] ||= []

--- a/app/views/sufia/homepage/_home_content.html.erb
+++ b/app/views/sufia/homepage/_home_content.html.erb
@@ -1,0 +1,9 @@
+<%# this is a very temporary placeholder %>
+<h2>Some selected areas of interest...</h2>
+<ul>
+<% CHF::SyntheticCategory.keys.each do |key| %>
+  <li>
+    <%= link_to key.to_s.humanize.titlecase, search_catalog_path(temp_synthetic_collection: key) %>
+  </li>
+<% end %>
+</ul>

--- a/config/initializers/sufia_catalog_search_builder_overrides.rb
+++ b/config/initializers/sufia_catalog_search_builder_overrides.rb
@@ -18,4 +18,9 @@ Rails.application.config.to_prepare do
     klass.send(:include, SearchBuilder::RestrictAdminSearchFields)
   end
 
+  unless klass.ancestors.include? SearchBuilder::SyntheticCategoryLimit
+    klass.send(:include, SearchBuilder::SyntheticCategoryLimit)
+    klass.synthetic_category_param = :temp_synthetic_collection
+  end
+
 end

--- a/lib/chf/synthetic_category.rb
+++ b/lib/chf/synthetic_category.rb
@@ -1,0 +1,122 @@
+module CHF
+  # Our "Synthetic categories" are lists of works put together
+  # based on other already existing metadata. For instance, any work
+  # with a genre "Portraits" OR a subject "Portraits, Group" OR a
+  # subject "Women in science" might be considered part of the
+  # synthetic category "Portraits & People"
+  #
+  # At present, we do NOT index these categories, rather we just
+  # dynamically fetch them by doing queries on a real index.
+  #
+  # There isn't right now API to determine what synthetic categories an
+  # individual work belongs to (rather than just being in the results of a
+  # fetch for the category), but there could be.
+  class SyntheticCategory
+    GENRE_FACET_SOLR_FIELD = ActiveFedora.index_field_mapper.solr_name("genre_string", :facetable)
+    SUBJECT_FACET_SOLR_FIELD = ActiveFedora.index_field_mapper.solr_name("subject", :facetable)
+
+    class_attribute :definitions, instance_writer: false
+    # Different collections keyed by colleciton symbol, value is a hash
+    # listing genres and subjects. Thing is member of synthetic collection
+    # if it has _any_ of the listed genres or _any_ of the listed subjects.
+    self.definitions = {
+      portraits_and_people: {
+        genre: ["Portraits"],
+        subject: ["Portraits, Group", "Women in science", "Employees"]
+      },
+      science_on_stamps: {
+        subject: ["Science on postage stamps"]
+      },
+      instruments_and_innovation: {
+        genre: ["Scientific apparatus and instrument"],
+        subject: ["Artillery", "Machinery", "Chemical apparatus",
+                  "Laboratories--Equipment and supplies",
+                  "Chemical laboratories--Equipment and supplies",
+                  "Glassware"]
+      },
+      alchemy: {
+        subject: ["Alchemy", "Alchemists"]
+      },
+      scientific_education: {
+        genre: ["Chemistry sets", "Molecular models"],
+        subject: ["Science--study and teaching"]
+      },
+      health_and_medicine: {
+        subject: [
+          "Toxicology",
+          "Gases, Asphyxiating and poisonous--Toxicology",
+          "Biology",
+          "Biochemistry",
+          "Hearing aids",
+          "Drugs",
+          "Electronics in space medicine",
+          "Infants--Health and hygiene",
+          "Medical botanists",
+          "Medical education",
+          "Medical electronics",
+          "Medical electronics--Equipment and supplies",
+          "Medical instruments and apparatus",
+          "Medical laboratories--Equipment and supplies",
+          "Medical laboratories--Equipment and supplies--Standards",
+          "Medical laboratory equipment industry",
+          "Medical physics",
+          "Medical sciences",
+          "Medical students",
+          "Medical technologists",
+          "Medicine",
+          "Medicine bottles",
+          "Newborn infants--Medical care",
+          "Public health",
+          "Space medicine",
+          "Women in medicine"
+        ]
+      }
+    }
+
+    def self.has_key?(category_key)
+      return unless category_key.present?
+      definitions.has_key?(category_key.to_sym)
+    end
+
+    def self.keys
+      definitions.keys
+    end
+
+    attr_accessor :category_key
+
+    def initialize(category_key)
+      unless self.class.has_key?(category_key)
+        raise ArgumentError, "No such category key: #{category_key}"
+      end
+      @category_key = category_key.to_sym
+    end
+
+    def solr_fq
+      fq_elements = []
+
+      if definition[:subject].present?
+        fq_elements << "#{SUBJECT_FACET_SOLR_FIELD}:(#{fq_or_statement definition[:subject]})"
+      end
+      if definition[:genre].present?
+        fq_elements << "#{GENRE_FACET_SOLR_FIELD}:(#{fq_or_statement definition[:genre]})"
+      end
+
+      fq_elements.join(" OR ")
+    end
+
+    protected
+
+    def definition
+      definitions[category_key]
+    end
+
+    def fq_or_statement(values)
+      values.
+        collect { |s| s.gsub '"', '\"'}. # escape double quotes
+        collect { |s| %Q{"#{s}"} }. # wrap in quotes
+        join(" OR ")
+    end
+
+
+  end
+end

--- a/spec/lib/chf/synthetic_category_spec.rb
+++ b/spec/lib/chf/synthetic_category_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+RSpec.describe CHF::SyntheticCategory, no_clean: true do
+  # Pretty ridiculous to check output with this hairy regexp for
+  # general shape of a good expected query. Def not perfect, but works
+  # for now.
+  EXPECTED_SHAPE = /\A
+        ( \w+\:
+          \(
+            ( \"[^"]+\"
+              (\sOR\s)?
+            )+
+          \)
+          (\sOR\s)?
+        )
+  /x
+
+  describe "solr_fq" do
+    CHF::SyntheticCategory.keys.each do |key|
+      it "translates #{key}" do
+        result = CHF::SyntheticCategory.new(key).solr_fq
+        expect(result).to match EXPECTED_SHAPE
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is not the final UI. We don't have "splash pages" yet. I don't intend to expose
the synthetic categories on the normal search results page, like it is now. But this gives us
a smaller piece to review, including in production, to make sure the general idea is sound.

refs #434, #435, #436, #437, #438, #439