### PR TITLE
Move generic_work translations to new generic_work locale file, fix #458

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -21,43 +21,6 @@
 
 en:
   simple_form:
-    labels:
-      generic_work:
-        genre_string: "Genre"
-        identifier: "External ID"
-        date_of_work: "Date"
-        description: "Description"
-        resource_type: "Format"
-        division: "Department"
     hints:
       defaults:
         files: '' # no file hint for now
-      generic_work:
-        title: "Use a given title if available; otherwise, construct a brief descriptive title that uniquely identifies the work. Use title case (ex: \"The Quick Brown Fox Jumps Over the Lazy Dog\") for formal and published titles and sentence case (ex: \"The quick brown fox jumps over the lazy dog\") for constructed and supplied titles. Required to save."
-        additional_title: "Use for additional or varying form of title if it contributes to further identification of the work. Subtitles or translated titles can be recorded here (without brackets)."
-        identifier: "Enter an Object ID, Bibliographic or Item Number, Accession, ASpace Reference, or Oral History Interview Number. Use multiple IDs to distinguish the particular holding of a work with multiple copies. The external ID does not necessarily have to be unique but should point to a source record. Bib Numbers will be used to generate a link to the OPAC. <em><strong>Ex: • 2008.043.002 • B10337957</strong></em>. Required to save."
-        maker: "Any individual, group, or organization responsible for the work, either primarily or more auxiliary, if relevant. Field supports VIAF (includes Library of Congress/NACO authorities) autocomplete. If a name is not available, contact the Digital Projects and Metadata Librarian. Denote specific roles when possible; otherwise, Creator and Contributor can be used as default roles. Required if available."
-        date_of_work: "Date(s) of creation or publication. Three levels of granularity can be used for precise dates—year (<em>YYYY</em>), year-month (<em>YYYY-MM</em>), and year-month-day (<em>YYYY-MM-DD</em>). Input discrete dates into the Start field. For date ranges or uncertainties, accepted formats are <em>YYYY-YYYY</em>, <em>before YYYY</em>, <em>after YYYY</em>, <em>circa YYYY</em>, <em>YYY0 decade</em>, <em>YY00 century</em>, or <em>Undated</em>. For dates expressed in alternative formats or systems, record the original value as is in Note, which will display in parentheses after the W3C date. Required."
-        place: "Location of origin for the work. Regions can include neighborhood, city, state, or country. Note that places depicted in a work are topical and should be cataloged as <strong>Subjects</strong>. Field supports FAST (derived from Library of Congress authorities) autocomplete."
-        resource_type: "Format in which the work is expressed. Select the content type(s) that best reflects the original work and not the digital resource. Use Ctrl+click to make multiple selections. Required."
-        genre_string: "The nature of the work, covering aspects such as content, form, function, physical character, style, or technique. Select the genre(s) of the work or its content. If a desired term is not available, contact the Digital Projects and Metadata Librarian. Required."
-        medium: "Use for the materials or physical carrier of the work, primarily for 3D and highly visual objects. <strong><em>Ex: • Audiocassettes • Celluloid • Dye • Nylon</strong></em>."
-        extent: "Use for size or duration of work. Input numerical values up to two decimal places (avoid fractions to prevent confusion). If the value is less than one, precede the decimal marker with a zero. Specify dimensional sides (such as height <em>H</em> and width <em>W</em> for 2D materials, plus depth <em>D</em>, length <em>L</em>, diameter <em>Diam.</em>, or circumference <em>Circ.</em> for 3D objects) and units of measurement (whether metric or U.S.) when applicable. Use lowercase letters for units of measurement, with periods after U.S. system units only. For oral histories, detail number of transcript pages and the total audio running time in <em>hh:mm:ss</em>. <strong><em>Ex: • 0.75 in. H x 2.5 in. W • 80 cm L x 22 cm Diam. • 116 pages • 01:49:23</strong></em>. Recommended."
-        language: "Refers to language of the intellectual content of the work. Input the language of the work being described, even if it is a translation or if the original is in a different language. Field supports local autocomplete."
-        description: "Summary, highlights, or other contextual information about the work. Use full sentences for descriptive text. Enter specialized or additional information not included in other fields, and consider using keywords that users may search for. Existing abstracts can also be copied from available sources. Recommended. Allowed HHTML tags: b, i, cite, a."
-        inscription: "Use for text on a work that is captioned, dedicated, or inscribed. Input the inscription location (<strong><em>Ex: • Inside front cover • Verso bottom left • Back panel</strong></em>) and transcribe the text exactly as is on the work, including capturing misspellings, crossouts, or other anomalies as they appear."
-        subject: "Topical terms describing the “aboutness” of the work. Depicted persons, places, and time periods are covered here as well. Field supports FAST (derived from Library of Congress authorities) autocomplete. <strong><em>Ex: • Alchemy • Integrated circuits</strong></em>. Recommended."
-        division: "Select the CHF administrative entity responsible for the management and curation of the physical work. Required."
-        series_arrangement: "Archival materials only: specify series and subseries of work, where relevant. Capture the information as listed in the finding aid."
-        physical_container: "Archival and serialized materials only: specify either box/folder or volume/part numbers, where relevant."
-        #this field doesn't exist...
-        #Related Materials Other Hydra resources related to the work.
-        related_url: "Input permanent link(s) to additional information or content relating to the work outside of Hydra, such as URLs to OPAC records, finding aids, exhibit pages, and other collections resources. Recommended."
-        rights: "Information on copyright status and licensing. More TBD. Required."
-        rights_holder: "The individual or organization owning or managing rights to the work. Input the name of the copyright holder in natural order. Required if available."
-        credit_line: "Default attribution information for the work."
-        additional_credit: "Additional attribution information, such as for the digital representation of the work. Appends <strong>Credit Line</strong>."
-        # this field was deleted
-        #provenance: "Record of ownership or custody of the work."
-        file_creator: "Select the individual, group, or organization responsible for producing the digital representation of the work, such as the digitizing agent or file author. If a desired entry is not available, contact the Digital Projects and Metadata Librarian. Recommended."
-        admin_note: "Use for any internal notes about the digital object or physical work, such as copyright concerns, digitization errors, legacy metadata, etc. Record first initial, last name, and date with the note in case a follow-up is necessary."

--- a/config/locales/generic_work.en.yml
+++ b/config/locales/generic_work.en.yml
@@ -9,10 +9,12 @@ en:
   simple_form:
     labels:
       generic_work:
-        based_near:       "Location"
-        description:      "Abstract or Summary"
-        keyword:          "Keyword"
-        date_created:     "Date Created"
+        genre_string: "Genre"
+        identifier: "External ID"
+        date_of_work: "Date"
+        description: "Description"
+        resource_type: "Format"
+        division: "Department"
         related_url:      "Related URL"
         files:            "Upload a new version of this file from your computer"
         collection_ids:   "Add as member of collection"
@@ -20,18 +22,31 @@ en:
 
     hints:
       generic_work:
-        resource: "Pre-defined categories to describe the type of content being uploaded, such as &quot;article&quot; or &quot;dataset.&quot;  More than one type may be selected."
-        title: "A name to aid in identifying a work."
-        keyword: "Words or phrases you select to describe what the work is about. These are used to search for content."
-        subject: "Headings or index terms describing what the work is about; these do need to conform to an existing vocabulary."
-        creator: "The person or group responsible for the work. Usually this is the author of the content. Personal names should be entered with the last name first, e.g. &quot;Smith, John.&quot;."
-        related_url: "A link to a website or other specific content (audio, video, PDF document) related to the work. An example is the URL of a research project from which the work was derived."
-        based_near: "A place name related to the work, such as its site of publication, or the city, state, or country the work contents are about. Calls upon the <a href='http://www.geonames.org'>GeoNames web service</a>."
-        contributor: "A person or group you want to recognize for playing a role in the creation of the work, but not the primary role."
-        date_created: "The date on which the work was generated."
-        description: "Free-text notes about the work. Examples include abstracts of a paper or citation information for a journal article."
-        identifier: "A unique handle identifying the work. An example would be a DOI for a journal article, or an ISBN or OCLC number for a book."
-        language: "The language of the work's content."
-        publisher: "The person or group making the work available. Generally this is the institution."
-        rights: "Licensing and distribution information governing access to the work. Select from the provided drop-down list."
-
+        title: "Use a given title if available; otherwise, construct a brief descriptive title that uniquely identifies the work. Use title case (ex: \"The Quick Brown Fox Jumps Over the Lazy Dog\") for formal and published titles and sentence case (ex: \"The quick brown fox jumps over the lazy dog\") for constructed and supplied titles. Required to save."
+        additional_title: "Use for additional or varying form of title if it contributes to further identification of the work. Subtitles or translated titles can be recorded here (without brackets)."
+        identifier: "Enter an Object ID, Bibliographic or Item Number, Accession, ASpace Reference, or Oral History Interview Number. Use multiple IDs to distinguish the particular holding of a work with multiple copies. The external ID does not necessarily have to be unique but should point to a source record. Bib Numbers will be used to generate a link to the OPAC. <em><strong>Ex: • 2008.043.002 • B10337957</strong></em>. Required to save."
+        maker: "Any individual, group, or organization responsible for the work, either primarily or more auxiliary, if relevant. Field supports VIAF (includes Library of Congress/NACO authorities) autocomplete. If a name is not available, contact the Digital Projects and Metadata Librarian. Denote specific roles when possible; otherwise, Creator and Contributor can be used as default roles. Required if available."
+        date_of_work: "Date(s) of creation or publication. Three levels of granularity can be used for precise dates—year (<em>YYYY</em>), year-month (<em>YYYY-MM</em>), and year-month-day (<em>YYYY-MM-DD</em>). Input discrete dates into the Start field. For date ranges or uncertainties, accepted formats are <em>YYYY-YYYY</em>, <em>before YYYY</em>, <em>after YYYY</em>, <em>circa YYYY</em>, <em>YYY0 decade</em>, <em>YY00 century</em>, or <em>Undated</em>. For dates expressed in alternative formats or systems, record the original value as is in Note, which will display in parentheses after the W3C date. Required."
+        place: "Location of origin for the work. Regions can include neighborhood, city, state, or country. Note that places depicted in a work are topical and should be cataloged as <strong>Subjects</strong>. Field supports FAST (derived from Library of Congress authorities) autocomplete."
+        resource_type: "Format in which the work is expressed. Select the content type(s) that best reflects the original work and not the digital resource. Use Ctrl+click to make multiple selections. Required."
+        genre_string: "The nature of the work, covering aspects such as content, form, function, physical character, style, or technique. Select the genre(s) of the work or its content. If a desired term is not available, contact the Digital Projects and Metadata Librarian. Required."
+        medium: "Use for the materials or physical carrier of the work, primarily for 3D and highly visual objects. <strong><em>Ex: • Audiocassettes • Celluloid • Dye • Nylon</strong></em>."
+        extent: "Use for size or duration of work. Input numerical values up to two decimal places (avoid fractions to prevent confusion). If the value is less than one, precede the decimal marker with a zero. Specify dimensional sides (such as height <em>H</em> and width <em>W</em> for 2D materials, plus depth <em>D</em>, length <em>L</em>, diameter <em>Diam.</em>, or circumference <em>Circ.</em> for 3D objects) and units of measurement (whether metric or U.S.) when applicable. Use lowercase letters for units of measurement, with periods after U.S. system units only. For oral histories, detail number of transcript pages and the total audio running time in <em>hh:mm:ss</em>. <strong><em>Ex: • 0.75 in. H x 2.5 in. W • 80 cm L x 22 cm Diam. • 116 pages • 01:49:23</strong></em>. Recommended."
+        language: "Refers to language of the intellectual content of the work. Input the language of the work being described, even if it is a translation or if the original is in a different language. Field supports local autocomplete."
+        description: "Summary, highlights, or other contextual information about the work. Use full sentences for descriptive text. Enter specialized or additional information not included in other fields, and consider using keywords that users may search for. Existing abstracts can also be copied from available sources. Recommended. Allowed HHTML tags: b, i, cite, a."
+        inscription: "Use for text on a work that is captioned, dedicated, or inscribed. Input the inscription location (<strong><em>Ex: • Inside front cover • Verso bottom left • Back panel</strong></em>) and transcribe the text exactly as is on the work, including capturing misspellings, crossouts, or other anomalies as they appear."
+        subject: "Topical terms describing the “aboutness” of the work. Depicted persons, places, and time periods are covered here as well. Field supports FAST (derived from Library of Congress authorities) autocomplete. <strong><em>Ex: • Alchemy • Integrated circuits</strong></em>. Recommended."
+        division: "Select the CHF administrative entity responsible for the management and curation of the physical work. Required."
+        series_arrangement: "Archival materials only: specify series and subseries of work, where relevant. Capture the information as listed in the finding aid."
+        physical_container: "Archival and serialized materials only: specify either box/folder or volume/part numbers, where relevant."
+        #this field doesn't exist...
+        #Related Materials Other Hydra resources related to the work.
+        related_url: "Input permanent link(s) to additional information or content relating to the work outside of Hydra, such as URLs to OPAC records, finding aids, exhibit pages, and other collections resources. Recommended."
+        rights: "Information on copyright status and licensing. More TBD. Required."
+        rights_holder: "The individual or organization owning or managing rights to the work. Input the name of the copyright holder in natural order. Required if available."
+        credit_line: "Default attribution information for the work."
+        additional_credit: "Additional attribution information, such as for the digital representation of the work. Appends <strong>Credit Line</strong>."
+        # this field was deleted
+        #provenance: "Record of ownership or custody of the work."
+        file_creator: "Select the individual, group, or organization responsible for producing the digital representation of the work, such as the digitizing agent or file author. If a desired entry is not available, contact the Digital Projects and Metadata Librarian. Recommended."
+        admin_note: "Use for any internal notes about the digital object or physical work, such as copyright concerns, digitization errors, legacy metadata, etc. Record first initial, last name, and date with the note in case a follow-up is necessary."


### PR DESCRIPTION
fixes #458

The new file is broken out in support of per-work-type translations (e.g. if we want custom work types with custom metadata profiles for archives vs. oral histories). It was generated in the sufia 7.3 upgrade and I failed to fully attend to it.

Not sure what to make of the old one now; it just has one translation in it but I guess that's fine?