### PR TITLE
Synthetic Cateogry landing pages

### DIFF
--- a/app/controllers/synthetic_category_controller.rb
+++ b/app/controllers/synthetic_category_controller.rb
@@ -1,0 +1,51 @@
+# Only a 'show' action
+#
+# Based roughly off of Sufia/CurationConcerns CollectionController#show
+# TODO link to CollectionControllerBehavior in both
+class SyntheticCategoryController < ApplicationController
+    # include Blacklight::AccessControls::Catalog
+    include Blacklight::Base
+
+    # ??
+    copy_blacklight_config_from(::CatalogController)
+
+    def show
+      unless synthetic_category
+        raise ActionController::RoutingError.new("No SyntheticCategory matches `#{params[:id]}`")
+      end
+      set_response # trigger setting of @response, which I think some partials need.
+    end
+
+
+    protected
+
+    # Get controller to find templates in CollectionController too,
+    # so we can re-use more of the sufia stuff for collection. Messy messy.
+    def self.local_prefixes
+      @local_prefixes ||= super.push('collections')
+    end
+
+    def synthetic_category
+      @synthetic_cateogry = if CHF::SyntheticCategory.has_key?(params[:id])
+        CHF::SyntheticCategory.new(params[:id])
+      else
+        nil
+      end
+    end
+    helper_method :synthetic_category
+
+    def search_builder
+      @search_builder ||= SearchBuilder.new(self).tap { |sb| sb.synthetic_category_force = params[:id] }
+    end
+
+    def set_response
+      @response ||= repository.search( search_builder.with(params.merge(q: params[:cq])).query )
+    end
+
+    def results
+      set_response
+      @results ||= @response.documents
+    end
+    helper_method :results
+
+end

--- a/app/controllers/synthetic_category_controller.rb
+++ b/app/controllers/synthetic_category_controller.rb
@@ -26,16 +26,12 @@ class SyntheticCategoryController < ApplicationController
     end
 
     def synthetic_category
-      @synthetic_cateogry = if CHF::SyntheticCategory.has_key?(params[:id])
-        CHF::SyntheticCategory.new(params[:id])
-      else
-        nil
-      end
+      CHF::SyntheticCategory.from_slug(params[:id])
     end
     helper_method :synthetic_category
 
     def search_builder
-      @search_builder ||= SearchBuilder.new(self).tap { |sb| sb.synthetic_category_force = params[:id] }
+      @search_builder ||= SearchBuilder.new(self).tap { |sb| sb.synthetic_category_force = synthetic_category.category_key }
     end
 
     def set_response

--- a/app/models/search_builder/synthetic_category_limit.rb
+++ b/app/models/search_builder/synthetic_category_limit.rb
@@ -35,8 +35,8 @@ class SearchBuilder
     def synthetic_collection_limit(solr_params)
       synthetic_category = if synthetic_category_force.present?
         CHF::SyntheticCategory.new(synthetic_category_force)
-      elsif synthetic_category_param.present? && CHF::SyntheticCategory.has_key?(blacklight_params[synthetic_category_param])
-        CHF::SyntheticCategory.new(blacklight_params[synthetic_category_param])
+      elsif synthetic_category_param.present?
+        CHF::SyntheticCategory.from_slug(blacklight_params[synthetic_category_param])
       end
 
       if synthetic_category

--- a/app/views/sufia/homepage/_home_content.html.erb
+++ b/app/views/sufia/homepage/_home_content.html.erb
@@ -1,9 +1,9 @@
 <%# this is a very temporary placeholder %>
 <h2>Some selected areas of interest...</h2>
 <ul>
-<% CHF::SyntheticCategory.keys.each do |key| %>
+<% CHF::SyntheticCategory.all.each do |category| %>
   <li>
-    <%= link_to key.to_s.humanize.titlecase, search_catalog_path(temp_synthetic_collection: key) %>
+    <%= link_to category.title, synthetic_category_path(category) %>
   </li>
 <% end %>
 </ul>

--- a/app/views/sufia/homepage/_home_content.html.erb
+++ b/app/views/sufia/homepage/_home_content.html.erb
@@ -3,7 +3,7 @@
 <ul>
 <% CHF::SyntheticCategory.all.each do |category| %>
   <li>
-    <%= link_to category.title, synthetic_category_path(category) %>
+    <%= link_to category.title, synthetic_category_path(category.slug) %>
   </li>
 <% end %>
 </ul>

--- a/app/views/synthetic_category/_search_form.html.erb
+++ b/app/views/synthetic_category/_search_form.html.erb
@@ -1,0 +1,11 @@
+  <%= form_for "", method: :get, html: { class: "edit_collection form-search" } do |f| %>
+      <label class="sr-only"><%= t('curation_concerns.collections.search_form.label', title: presenter.to_s) %></label>
+      <div class="input-group">
+        <%= text_field_tag :cq, params[:cq], class: "collection-query form-control", placeholder: t('curation_concerns.collections.search_form.placeholder'), size: '30', type: "search", id: "collection_search" %>
+        <div class="input-group-btn">
+          <button type="submit" class="btn btn-primary" id="collection_submit"><i class="glyphicon glyphicon-search"></i> Go</button>
+        </div>
+      </div>
+      <%= hidden_field_tag :sort, params[:sort], id: 'collection_sort' %>
+      <%= render_hash_as_hidden_fields(search_state.params_for_search.except(:cq, :sort, :qt, :page)) %>
+  <% end %>

--- a/app/views/synthetic_category/_sort_and_per_page.html.erb
+++ b/app/views/synthetic_category/_sort_and_per_page.html.erb
@@ -1,0 +1,24 @@
+<%# copied and modified from
+https://github.com/projecthydra/sufia/blob/8bb451451a492e443687f8c5aff4882cac56a131/app/views/collections/_sort_and_per_page.html.erb
+%>
+
+<div class="sort-toggle">
+     <% if @response.response['numFound'] > 1 && !sort_fields.empty? %>
+        <%= form_tag "", method: :get, class: 'per_page form-horizontal' do %>
+             <div class="form-group form-group-lg">
+               <fieldset class="col-xs-12 col-sm-9 col-md-8 col-lg-10">
+                 <legend class="sr-only"><%= t('sufia.sort_label') %></legend>
+                 <%= label_tag(:sort, "<span>Sort By:</span>".html_safe) %>
+                 <%= select_tag(:sort, options_for_select(sort_fields, h(params[:sort]))) %>
+                 <%= label_tag(:per_page) do %>
+                     Show <%= select_tag(:per_page, options_for_select(['10', '20', '50', '100'], h(params[:per_page])), title: "Number of results to display per page") %>
+                     per page
+                 <% end %>
+                 <%= render_hash_as_hidden_fields(search_state.params_for_search.except(:per_page, :sort)) %>
+                 &nbsp;&nbsp;&nbsp;
+                 <button class="btn btn-info"><span class="glyphicon glyphicon-refresh"></span> Refresh</button>
+               </fieldset>
+             </div>
+         <% end %>
+      <% end %>
+</div>

--- a/app/views/synthetic_category/show.html.erb
+++ b/app/views/synthetic_category/show.html.erb
@@ -1,0 +1,36 @@
+<%# largely copied and altered/simplified  from
+https://github.com/projecthydra/sufia/blob/v7.3.0/app/views/collections/show.html.erb
+
+To look like that, so it can even use the same styles,
+but be simpler just based on a simple SyntheticCategory
+%>
+
+<% provide :page_title, construct_page_title(synthetic_category.title) %>
+
+<div itemscope itemtype="http://schema.org/CollectionPage" class="row">
+  <div class="col-sm-10 pull-right">
+    <header>
+      <h1><%= synthetic_category.title %></h1>
+    </header>
+
+    <p class="collection_description"><%= synthetic_category.description %></p>
+  </div>
+  <div class="col-sm-2">
+    <%# replace with custom graphic %>
+    <span class="<%= Sufia::ModelIcon.css_class_for(Collection) %> collection-icon-search"></span>
+  </div>
+</div>
+
+<div class="row">
+  <h2 class="col-xs-6 col-md-7 col-lg-6">
+    Items in <%= synthetic_category.title %>
+  </h2>
+  <div class="col-xs-6 col-md-5 col-lg-6"><%= render 'search_form', presenter: synthetic_category %></div>
+</div>
+
+
+<%= render 'sort_and_per_page' %>
+
+<%= render_document_index results %>
+
+<%= render 'paginate' %>

--- a/config/initializers/sufia_catalog_search_builder_overrides.rb
+++ b/config/initializers/sufia_catalog_search_builder_overrides.rb
@@ -20,7 +20,6 @@ Rails.application.config.to_prepare do
 
   unless klass.ancestors.include? SearchBuilder::SyntheticCategoryLimit
     klass.send(:include, SearchBuilder::SyntheticCategoryLimit)
-    klass.synthetic_category_param = :temp_synthetic_collection
   end
 
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,9 +12,9 @@ Rails.application.routes.draw do
       mount Resque::Server, at: 'queues'
     end
   end
-  
+
   mount Blacklight::Engine => '/'
-  
+
     concern :searchable, Blacklight::Routes::Searchable.new
 
   resource :catalog, only: [:index], as: 'catalog', path: '/catalog', controller: 'catalog' do
@@ -46,6 +46,8 @@ Rails.application.routes.draw do
   # local routes
   get '/opac_data/:rec_num', to: 'opac_data#load_bib'
   mount Hydra::RoleManagement::Engine => '/'
+
+  get '/focus/:id', to: 'synthetic_category#show'
 
 
   Hydra::BatchEdit.add_routes(self)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -47,7 +47,7 @@ Rails.application.routes.draw do
   get '/opac_data/:rec_num', to: 'opac_data#load_bib'
   mount Hydra::RoleManagement::Engine => '/'
 
-  get '/focus/:id', to: 'synthetic_category#show'
+  get '/focus/:id', to: 'synthetic_category#show', as: :synthetic_category
 
 
   Hydra::BatchEdit.add_routes(self)

--- a/lib/chf/synthetic_category.rb
+++ b/lib/chf/synthetic_category.rb
@@ -95,6 +95,9 @@ module CHF
       keys.collect { |key| self.new(key) }
     end
 
+    # Our symbol keys use underscores eg `:portraits_and_people`, but it's nicer
+    # to have hyphens in the URL eg `/portraits-and-people`. Look up a SyntheticCategory
+    # object from slug in URL.
     def self.from_slug(slug)
       if slug.blank?
         nil
@@ -110,6 +113,9 @@ module CHF
 
     attr_accessor :category_key
 
+    # Our symbol keys use underscores eg `:portraits_and_people`, but it's nicer
+    # to have hyphens in the URL eg `/portraits-and-people`. Translate to a slug
+    # suitable for use in a URL, see also .from_slug.
     def slug
       category_key.to_s.dasherize
     end

--- a/lib/chf/synthetic_category.rb
+++ b/lib/chf/synthetic_category.rb
@@ -22,26 +22,33 @@ module CHF
     self.definitions = {
       portraits_and_people: {
         genre: ["Portraits"],
-        subject: ["Portraits, Group", "Women in science", "Employees"]
+        subject: ["Portraits, Group", "Women in science", "Employees"],
+        title: "Portraits & People",
+        description: "A selection of our digitized material on interesting people in the history of science, CHF has some great ones."
       },
       science_on_stamps: {
-        subject: ["Science on postage stamps"]
+        subject: ["Science on postage stamps"],
+        description: "CHF has some great postage stamps from around the world on science topics. Here are some we've digitized."
       },
       instruments_and_innovation: {
         genre: ["Scientific apparatus and instrument"],
         subject: ["Artillery", "Machinery", "Chemical apparatus",
                   "Laboratories--Equipment and supplies",
                   "Chemical laboratories--Equipment and supplies",
-                  "Glassware"]
+                  "Glassware"],
+        description: "CHF's collections include a focus on instruments and innovation in scientific tools, here are some interesting materials we've digitized."
       },
       alchemy: {
-        subject: ["Alchemy", "Alchemists"]
+        subject: ["Alchemy", "Alchemists"],
+        description: "Alchemy is an interesting part of the history of chemistry."
       },
       scientific_education: {
         genre: ["Chemistry sets", "Molecular models"],
-        subject: ["Science--study and teaching"]
+        subject: ["Science--study and teaching"],
+        description: "Alchemy is an interesting part of the history of chemistry. Here are some digitized items from our extensive collections."
       },
       health_and_medicine: {
+        description: "Selected digitized items from the CHF collections on topics of health and medicine.",
         subject: [
           "Toxicology",
           "Gases, Asphyxiating and poisonous--Toxicology",
@@ -82,6 +89,10 @@ module CHF
       definitions.keys
     end
 
+    def self.all
+      keys.collect { |key| self.new(key) }
+    end
+
     attr_accessor :category_key
 
     def initialize(category_key)
@@ -89,6 +100,28 @@ module CHF
         raise ArgumentError, "No such category key: #{category_key}"
       end
       @category_key = category_key.to_sym
+    end
+
+    def title
+      # This could use i18n, but this simpler seems good enough for now,
+      # We don't even use locales anyway.
+      if definition.has_key?(:title)
+        definition[:title]
+      else
+        category_key
+      end
+    end
+
+    def description
+      # This could use i18n, but this simpler seems good enough for now,
+      # We don't even use locales anyway.
+      if definition.has_key?(:description_html)
+        definition[:description_html].html_safe
+      elsif definition.has_key?(:description)
+        definition[:description]
+      else
+        nil
+      end
     end
 
     def solr_fq

--- a/lib/chf/synthetic_category.rb
+++ b/lib/chf/synthetic_category.rb
@@ -95,7 +95,22 @@ module CHF
       keys.collect { |key| self.new(key) }
     end
 
+    def self.from_slug(slug)
+      if has_key?(slug)
+        self.new(slug)
+      elsif has_key?(slug.underscore)
+        self.new(slug.underscore)
+      else
+        nil
+      end
+    end
+
+
     attr_accessor :category_key
+
+    def slug
+      category_key.to_s.dasherize
+    end
 
     def initialize(category_key)
       unless self.class.has_key?(category_key)

--- a/lib/chf/synthetic_category.rb
+++ b/lib/chf/synthetic_category.rb
@@ -46,7 +46,7 @@ module CHF
       scientific_education: {
         genre: ["Chemistry sets", "Molecular models"],
         subject: ["Science--study and teaching"],
-        description: "Alchemy is an interesting part of the history of chemistry. Here are some digitized items from our extensive collections."
+        description: "Chemistry sets and more."
       },
       health_and_medicine: {
         title: "Health & Medicine",

--- a/lib/chf/synthetic_category.rb
+++ b/lib/chf/synthetic_category.rb
@@ -96,7 +96,9 @@ module CHF
     end
 
     def self.from_slug(slug)
-      if has_key?(slug)
+      if slug.blank?
+        nil
+      elsif has_key?(slug)
         self.new(slug)
       elsif has_key?(slug.underscore)
         self.new(slug.underscore)

--- a/lib/chf/synthetic_category.rb
+++ b/lib/chf/synthetic_category.rb
@@ -31,6 +31,7 @@ module CHF
         description: "CHF has some great postage stamps from around the world on science topics. Here are some we've digitized."
       },
       instruments_and_innovation: {
+        title: "Instruments & Innovation",
         genre: ["Scientific apparatus and instrument"],
         subject: ["Artillery", "Machinery", "Chemical apparatus",
                   "Laboratories--Equipment and supplies",
@@ -48,6 +49,7 @@ module CHF
         description: "Alchemy is an interesting part of the history of chemistry. Here are some digitized items from our extensive collections."
       },
       health_and_medicine: {
+        title: "Health & Medicine",
         description: "Selected digitized items from the CHF collections on topics of health and medicine.",
         subject: [
           "Toxicology",
@@ -108,7 +110,7 @@ module CHF
       if definition.has_key?(:title)
         definition[:title]
       else
-        category_key
+        category_key.to_s.humanize.titlecase
       end
     end
 


### PR DESCRIPTION
With more control of titles of synth categories. 

The `synthetic_category_param` is unset, no longer allow query params to
set category limits on ordinary results page, instead you use the category
landing pages, woot.