### PR TITLE
Change 'In generic work' label, and don't show on empty.

### DIFF
--- a/app/controllers/curation_concerns/generic_works_controller.rb
+++ b/app/controllers/curation_concerns/generic_works_controller.rb
@@ -9,5 +9,30 @@ module CurationConcerns
 
     self.curation_concern_type = GenericWork
     self.show_presenter = CurationConcerns::GenericWorkShowPresenter
+
+
+    protected
+
+    # Pretty hacky way to override the t() I18n method when called from template:
+    # https://github.com/projecthydra/sufia/blob/8bb451451a492e443687f8c5aff4882cac56a131/app/views/curation_concerns/base/_relationships_parent_row.html.erb
+    # ...so  we can catch what would have been "In Generic work" and replace with
+    # "Part of", while still calling super for everything else, to try and
+    # avoid breaking anything else.
+    #
+    # The way this is set up upstream, I honestly couldn't figure out
+    # a better way to intervene without higher chance of forwards-compat
+    # problems on upgrades. It could not be overridden just in i18n to do
+    # what we want.
+    module HelperOverride
+      def t(key, interpolations = {})
+        if key == ".label" && interpolations[:type] == "Generic work"
+          "Part of:"
+        else
+          super
+        end
+      end
+    end
+    helper HelperOverride
+
   end
 end

--- a/app/views/curation_concerns/base/_relationships_parent_row_empty.html.erb
+++ b/app/views/curation_concerns/base/_relationships_parent_row_empty.html.erb
@@ -1,0 +1,10 @@
+<%# copied from https://github.com/projecthydra/sufia/blob/8bb451451a492e443687f8c5aff4882cac56a131/app/views/curation_concerns/base/_relationships_parent_row_empty.html.erb
+  # and modified to suppress empty rows for certain 'types', mainly the parent work thing %>
+<% unless ['generic_work'].include? type %>
+  <tr>
+    <th><%= t(".label", type: type.humanize) %></th>
+    <td>
+      <p><%= t(".empty", type: type.humanize) %></p>
+    </td>
+  </tr>
+<% end %>


### PR DESCRIPTION
I am not a huge fan of how I did either of these things either -- I just like
this intervention better than anything else I could come up with, which was even awfuller,
and would involve overriding larger parts of sufia/CC and risking forwards compat problems,
or making the code even more confusing and harder to find what was going on. 

I am thinking when we overhaul the 'show' page generally, I'd like to just override
the actual `show` template, and stop using some parts of the sufia/cc/hyrax abstraction
architecture which are over-engineered and hard to work with without actually providing
customization hooks we need to do what we needed here.

Closes #492 #493 