### PR TITLE
Add item count to synthetic category collection-like display.

### DIFF
--- a/app/views/synthetic_category/_sort_and_per_page.html.erb
+++ b/app/views/synthetic_category/_sort_and_per_page.html.erb
@@ -18,6 +18,9 @@ https://github.com/projecthydra/sufia/blob/8bb451451a492e443687f8c5aff4882cac56a
                  &nbsp;&nbsp;&nbsp;
                  <button class="btn btn-info"><span class="glyphicon glyphicon-refresh"></span> Refresh</button>
                </fieldset>
+                 <div class="view-type col-xs-12 col-sm-3 col-md-4 col-lg-2">
+                   <strong><%= @response.total %> Items</strong>
+                 </div>
              </div>
          <% end %>
       <% end %>


### PR DESCRIPTION
Unlike real collection display, it will show you the count of your result set when
you do a search-inside-the-thing too.

Put it in the space occupied by 'view type' selector in real collections, which we don't use,
since it was available space, and anna said she thought the blank space made things look odd,
and right under the search box seems like a good place when it updates for your current result set.

That means it goes in the "sort and per page" partial, even though it's not really about
sort and per page (neither are view types really!), in order to take advantage of existing
collection CSS consistently.