### PR TITLE
Fixity in our app

### DIFF
--- a/app/services/chf/fixity_check_failure_service.rb
+++ b/app/services/chf/fixity_check_failure_service.rb
@@ -45,7 +45,7 @@ module CHF
 <p>file: #{file_id}
   <a href="#{file_fedora_metadata_uri}">#{file_fedora_metadata_uri}</a></p>
 
-<p>Logged in ChecksumAuditLog: #{checksum_audit_log.inspect}</p>
+<p>Logged in ChecksumAuditLog: #{ERB::Util.html_escape checksum_audit_log.inspect}</p>
   EOF
     end
 

--- a/app/services/chf/fixity_check_failure_service.rb
+++ b/app/services/chf/fixity_check_failure_service.rb
@@ -1,0 +1,101 @@
+module CHF
+  class FixityCheckFailureService
+    attr_reader :log_date, :checksum_audit_log, :file_set
+
+    def initialize(file_set, checksum_audit_log:)
+      @file_set = file_set
+      @checksum_audit_log = checksum_audit_log
+    end
+
+    def call
+      # send an email to digital-tech
+      ActionMailer::Base.mail(from: "digital-tech@chemheritage.org",
+                              to: "digital-tech@chemheritage.org",
+                              subject: subject,
+                              content_type: "text/html",
+                              body: message).deliver_later
+
+      # Send in-app messages to all admins. Who knows if sendio will
+      # block the email anyway.
+      admin_role = Role.where(name: 'admin').first
+      if admin_role
+        admin_role.users.each do |user|
+          ::User.audit_user.send_message(user, message, subject)
+        end
+      end
+    end
+
+    def message
+      <<-EOF
+<p>hostname: #{`hostname`.chomp}</p>
+
+<p>Fixity check failure at #{log_created_at}<br>
+  for: <a href="#{checked_uri}/fcr:metadata">#{checked_uri}/fcr:metadata</a></p>
+
+<p>Expected fixity result: #{expected_result}</p>
+
+<p>work:
+  #{works_message}</p>
+
+
+<p>file_set: #{file_set_id} #{file_set_title}
+  <a href="#{file_set_app_path}">#{file_set_app_path}</a>
+  <a href="#{file_set.try(:uri)}/fcr:metadata">#{file_set.try(:uri)}/fcr:metadata</a></p>
+
+<p>file: #{file_id}
+  <a href="#{file_fedora_metadata_uri}">#{file_fedora_metadata_uri}</a></p>
+
+<p>Logged in ChecksumAuditLog: #{checksum_audit_log.inspect}</p>
+  EOF
+    end
+
+    def subject
+      "FIXITY CHECK FAILURE: #{file_set_title}"
+    end
+
+    protected
+
+    def file_id
+      checksum_audit_log.file_id
+    end
+
+    def works
+      file_set.try(:in_works) || []
+    end
+
+    def works_message
+      works.to_a.collect do |w|
+        "  #{w.try(:title).try(:first)} #{w.id} <a href='#{Rails.application.routes.url_helpers.curation_concerns_generic_work_path(w)}'>#{Rails.application.routes.url_helpers.curation_concerns_generic_work_path(w)}</a>"
+      end.join("\n")
+    end
+
+    def file_fedora_metadata_uri
+      file_uri = Hydra::PCDM::File.translate_id_to_uri.call(file_id)
+      file_uri && "#{file_uri}/fcr:metadata"
+    end
+
+    def log_created_at
+      checksum_audit_log.try(:created_at).try(:in_time_zone).try(:to_s)
+    end
+
+    def file_set_id
+      checksum_audit_log.try(:file_set_id)
+    end
+
+    def file_set_title
+      file_set.try(:title).try(:first)
+    end
+
+    def file_set_app_path
+      Rails.application.routes.url_helpers.curation_concerns_file_set_path(works.first, file_set) if file_set && works.present?
+    end
+
+    def checked_uri
+      checksum_audit_log.try(:checked_uri)
+    end
+
+    def expected_result
+      checksum_audit_log.try(:expected_result)
+    end
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -24,6 +24,8 @@ module Chufia
     config.autoload_paths << "#{Rails.root}/app/forms/concerns"
     # Load files from lib/
     config.autoload_paths << Rails.root.join('lib')
+    # Load all subdirs of './patches'
+    config.autoload_paths.concat Dir.glob(Rails.root.join("patches/*"))
 
     config.generators do |g|
       g.test_framework :rspec, :spec => true

--- a/config/initializers/curation_concerns.rb
+++ b/config/initializers/curation_concerns.rb
@@ -3,4 +3,9 @@ CurationConcerns.configure do |config|
   # prior to being ingested into the repository or having derivatives generated.
   # If you use a multi-server architecture, this MUST be a shared volume.
   config.working_path = Rails.env.production? ? '/tmp/working' : (ENV['SUFIA_TMP_PATH'] || '/tmp')
+
+  CurationConcerns.config.callback.set(:after_fixity_check_failure) do |file_set, checksum_audit_log:|
+    CHF::FixityCheckFailureService.new(file_set, checksum_audit_log: checksum_audit_log).call
+  end
 end
+

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -6,3 +6,7 @@ env :PATH, ENV['PATH']
 every 1.month do
   rake "chf:metadata_report"
 end
+
+every 1.day, :at => '2:30 am' do
+  rake "chf:fixity_checks"
+end

--- a/db/migrate/20170516222881_change_checksum_audit_log.hyrax.rb
+++ b/db/migrate/20170516222881_change_checksum_audit_log.hyrax.rb
@@ -1,0 +1,9 @@
+# This migration comes from hyrax (originally 20170504192714)
+class ChangeChecksumAuditLog < ActiveRecord::Migration
+  def change
+    rename_column :checksum_audit_logs, :version, :checked_uri
+    change_column :checksum_audit_logs, :pass, :boolean
+    rename_column :checksum_audit_logs, :pass, :passed
+    add_index     :checksum_audit_logs, :checked_uri
+  end
+end

--- a/db/migrate/20170516222881_change_checksum_audit_log.hyrax.rb
+++ b/db/migrate/20170516222881_change_checksum_audit_log.hyrax.rb
@@ -2,8 +2,19 @@
 class ChangeChecksumAuditLog < ActiveRecord::Migration
   def change
     rename_column :checksum_audit_logs, :version, :checked_uri
-    change_column :checksum_audit_logs, :pass, :boolean
-    rename_column :checksum_audit_logs, :pass, :passed
+    add_column    :checksum_audit_logs, :pass, :passed
+
+    reversible do |dir|
+      dir.up do
+        ChecksumAuditLog.find_each { |log| log.update!(passed: log.pass ) }
+      end
+      dir.down do
+        ChecksumAuditLog.find_each { |log| log.update!(pass: log.passed ) }
+      end
+    end
+
+    remove_column :checksum_audit_log, :pass
     add_index     :checksum_audit_logs, :checked_uri
   end
 end
+

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170322170210) do
+ActiveRecord::Schema.define(version: 20170516222881) do
 
   create_table "bookmarks", force: :cascade do |t|
     t.integer  "user_id",       null: false
@@ -28,14 +28,15 @@ ActiveRecord::Schema.define(version: 20170322170210) do
   create_table "checksum_audit_logs", force: :cascade do |t|
     t.string   "file_set_id"
     t.string   "file_id"
-    t.string   "version"
-    t.integer  "pass"
+    t.string   "checked_uri"
+    t.boolean  "passed"
     t.string   "expected_result"
     t.string   "actual_result"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
+  add_index "checksum_audit_logs", ["checked_uri"], name: "index_checksum_audit_logs_on_checked_uri"
   add_index "checksum_audit_logs", ["file_set_id", "file_id"], name: "by_file_set_id_and_file_id"
 
   create_table "content_blocks", force: :cascade do |t|

--- a/lib/tasks/chf_tasks.rake
+++ b/lib/tasks/chf_tasks.rake
@@ -2,6 +2,14 @@ require_dependency Rails.root.join('lib','chf','reports','metadata_completion_re
 
 namespace :chf do
 
+  desc "run fixity checks with logs and notification on failure"
+  task :fixity_checks => :environment do
+    ::FileSet.find_each do |gf|
+      Hyrax::FileSetFixityCheckService.new(gf, async_jobs: false, latest_version_only: true).fixity_check
+    end
+  end
+
+
   desc 'Rough count metadata completion'
   task metadata_report: :environment do
     report = CHF::Reports::MetadataCompletionReport.new

--- a/patches/fixity_checks/README.md
+++ b/patches/fixity_checks/README.md
@@ -13,5 +13,11 @@ this patch, but some changes to internal implementation were made to
 not rely on other "Hyrax" namespaced infrastructure outside of this patch,
 but instead use our current "Sufia" infrastructure.
 
+This also includes an ActiveFedora backport, to return expected_message_digest,
+that is used by the Hyrax backport.
+
 It is expected this entire patch can be removed when we are on a hyrax
 implementing https://github.com/projecthydra-labs/hyrax/pull/984 / 1015
+
+And AF 11.3 or otherwise inclusion of:
+https://github.com/projecthydra/active_fedora/pull/1239

--- a/patches/fixity_checks/README.md
+++ b/patches/fixity_checks/README.md
@@ -1,0 +1,17 @@
+This patch backports improvements in fixity checking services from
+Hyrax to our app.
+
+The Hyrax fixes are not expected to be until Hyrax 2.0.
+
+We were on Sufia 7.3.0 at time this patch was made.
+
+https://github.com/projecthydra-labs/hyrax/pull/984
+https://github.com/projecthydra-labs/hyrax/pull/1015
+
+Names were left under "Hyrax" namespace for easier copy and paste into
+this patch, but some changes to internal implementation were made to
+not rely on other "Hyrax" namespaced infrastructure outside of this patch,
+but instead use our current "Sufia" infrastructure.
+
+It is expected this entire patch can be removed when we are on a hyrax
+implementing https://github.com/projecthydra-labs/hyrax/pull/984 / 1015

--- a/patches/fixity_checks/active_fedora/fixity_service.rb
+++ b/patches/fixity_checks/active_fedora/fixity_service.rb
@@ -2,7 +2,7 @@ module ActiveFedora
   # Backported from ActiveFedora, expected in AF 11.3
   # https://github.com/projecthydra/active_fedora/pull/1239
   # Adds support for returning expected_message_digest
-  if Gem.loaded_specs["active-fedora"] >= Gem::Version.new('11.3')
+  if Gem.loaded_specs["active-fedora"].version >= Gem::Version.new('11.3')
     msg = "\n\nPlease check and make sure this ActiveFedora patch is still needed at #{__FILE__}:#{__LINE__}\n\n"
     $stderr.puts msg
     Rails.logger.warn msg

--- a/patches/fixity_checks/active_fedora/fixity_service.rb
+++ b/patches/fixity_checks/active_fedora/fixity_service.rb
@@ -1,0 +1,101 @@
+module ActiveFedora
+  # Backported from ActiveFedora, expected in AF 11.3
+  # https://github.com/projecthydra/active_fedora/pull/1239
+  # Adds support for returning expected_message_digest
+  if Gem.loaded_specs["active-fedora"] >= Gem::Version.new('11.3')
+    msg = "\n\nPlease check and make sure this ActiveFedora patch is still needed at #{__FILE__}:#{__LINE__}\n\n"
+    $stderr.puts msg
+    Rails.logger.warn msg
+  end
+  class FixityService
+    extend ActiveSupport::Concern
+
+    attr_accessor :target
+
+    # @param [String, RDF::URI] target url for a Fedora resource.
+    def initialize(target)
+      raise ArgumentError, 'You must provide a uri' unless target
+      @target = target.to_s
+    end
+
+    def response
+      @response ||= fixity_response_from_fedora
+    end
+
+    # For backwards compat, check always insists on doing a new request.
+    # you might want verified? instead which uses a cached request.
+    # @return true or false
+    def check
+      @response = nil
+      verified?
+    end
+
+    # Executes a fixity check on Fedora
+    # @return true or false
+    def verified?
+      status.include?(success)
+    end
+
+    # An array of 1 or more literals reported by Fedora.
+    # See 'success' for which one indicates fixity check is good.
+    def status
+      fixity_graph.query(predicate: premis_status_predicate).map(&:object) +
+        fixity_graph.query(predicate: fedora_status_predicate).map(&:object)
+    end
+
+    # the currently calculated checksum, as a string URI, like
+    # "urn:sha1:09a848b79f86f3a4f3f301b8baafde455d6f8e0e"
+    def expected_message_digest
+      fixity_graph.query(predicate: ::RDF::Vocab::PREMIS.hasMessageDigest).first.try(:object).try(:to_s)
+    end
+
+    # integer, as reported by fedora. bytes maybe?
+    def expected_size
+      fixity_graph.query(predicate: ::RDF::Vocab::PREMIS.hasSize).first.try(:object).try(:to_s).try(:to_i)
+    end
+
+    # Fedora response as an ::RDF::Graph object. Public API, so consumers
+    # can do with it what they will, especially if future fedora versions
+    # add more things to it.
+    def response_graph
+      fixity_graph
+    end
+
+    private
+
+      def premis_status_predicate
+        ::RDF::Vocab::PREMIS.hasEventOutcome
+      end
+
+      # Fcrepo4.status was used by Fedora < 4.3, but it was removed
+      # from the 2015-07-24 version of the fedora 4 ontology
+      # http://fedora.info/definitions/v4/2015/07/24/repository and
+      # from rdf-vocab in version 0.8.5
+      def fedora_status_predicate
+        ::RDF::URI("http://fedora.info/definitions/v4/repository#status")
+      end
+
+      def success
+        ::RDF::Literal.new("SUCCESS")
+      end
+
+      def fixity_response_from_fedora
+        uri = target + "/fcr:fixity"
+        ActiveFedora.fedora.connection.get(encoded_url(uri))
+      end
+
+      def fixity_graph
+        @fixity_graph ||= ::RDF::Graph.new << ::RDF::Reader.for(:ttl).new(response.body)
+      end
+
+      # See https://jira.duraspace.org/browse/FCREPO-1247
+      # @param [String] uri
+      def encoded_url(uri)
+        if uri =~ /fcr:versions/
+          uri.gsub(/fcr:versions/, "fcr%3aversions")
+        else
+          uri
+        end
+      end
+  end
+end

--- a/patches/fixity_checks/checksum_audit_log.rb
+++ b/patches/fixity_checks/checksum_audit_log.rb
@@ -1,0 +1,58 @@
+# Backported from https://github.com/projecthydra-labs/hyrax/pull/984
+# https://github.com/projecthydra-labs/hyrax/pull/1015
+# Expected in Hyrax 2.0
+if Gem.loaded_specs["hyrax"] && Gem.loaded_specs["hyrax"].version >= Gem::Version.new('2.0')
+  msg = "\n\nPlease check and make sure this fixity check patch is still needed at #{__FILE__}:#{__LINE__}\n\n"
+  $stderr.puts msg
+  Rails.logger.warn msg
+end
+
+class ChecksumAuditLog < ActiveRecord::Base
+  def failed?
+    !passed?
+  end
+
+  # Only the latest rows for a given file_set_id/checked_uri pair.
+  # Uses a join, so you might have to be careful combining. You would
+  # normally combine this with other conditions, this alone will return
+  # LOTS of records.
+  def self.latest_checks
+    # one crazy SQL trick to get the latest for each fileset/checked_uri combo
+    # where there's no other self-join created_at greater -- only the greatest.
+    joins("LEFT JOIN checksum_audit_logs c2 ON
+            (checksum_audit_logs.file_set_id = c2.file_set_id AND
+             checksum_audit_logs.checked_uri = c2.checked_uri AND
+             checksum_audit_logs.created_at < c2.created_at)")
+      .where("c2.id is NULL")
+      .order("created_at desc, id desc")
+  end
+
+  # From all ChecksumAuditLogs related to this file set, returns only
+  # the LATEST for each file_set_id/checked_uri pair.
+  def self.latest_for_file_set_id(file_set_id)
+    latest_checks.where(file_set_id: file_set_id)
+  end
+
+  # Prune old ChecksumAuditLog records. We keep only:
+  # * Latest check
+  # * failing checks
+  # * any checks immediately before or after a failing check,
+  #   to provide context on known good dates surrounding failing.
+  def self.prune_history(file_set_id, checked_uri:)
+    all_logs = logs_for(file_set_id, checked_uri: checked_uri).reorder("created_at asc").to_a
+
+    0.upto(all_logs.length - 2).each do |i|
+      next if all_logs[i].failed?
+      next if i > 0 && all_logs[i - 1].failed?
+      next if all_logs[i + 1].failed?
+
+      all_logs[i].destroy!
+    end
+  end
+
+  # All logs for a particular file or version in a give file set, sorted
+  # by date descending.
+  def self.logs_for(file_set_id, checked_uri:)
+    ChecksumAuditLog.where(file_set_id: file_set_id, checked_uri: checked_uri).order('created_at desc, id desc')
+  end
+end

--- a/patches/fixity_checks/curation_concerns/file_set_audit_service.rb
+++ b/patches/fixity_checks/curation_concerns/file_set_audit_service.rb
@@ -1,0 +1,24 @@
+module CurationConcerns
+  # Override CurationConcerns::FileSetAuditService to basically be our new backported
+  # Hyrax::FileSetFixityCheckService, to catch parts of the current sufia stack
+  # that try to use CurationConcerns::FileSetAuditService. Mainly
+  # the views/curation_concerns/file_sets/_show_details partial.
+
+  if Gem.loaded_specs["hyrax"]
+    msg = "\n\nPlease check and make sure this fixity check patch is still needed at #{__FILE__}:#{__LINE__}\n\n"
+    $stderr.puts msg
+    Rails.logger.warn msg
+  end
+
+  class FileSetAuditService < Hyrax::FileSetFixityCheckService
+
+    def audit(*args)
+      fixity_check
+    end
+
+
+    def logged_audit_status
+      Hyrax::FixityStatusPresenter.new(file_set.id).render_file_set_status
+    end
+  end
+end

--- a/patches/fixity_checks/fixity_check_job.rb
+++ b/patches/fixity_checks/fixity_check_job.rb
@@ -35,11 +35,11 @@ class FixityCheckJob < ActiveJob::Base
     uri = uri.to_s # sometimes we get an RDF::URI gah
     log = run_check(file_set_id, file_id, uri)
 
-    if log.failed? && Sufia.config.callback.set?(:after_fixity_check_failure)
+    if log.failed? && CurationConcerns.config.callback.set?(:after_fixity_check_failure)
       file_set = ::FileSet.find(file_set_id)
-      Sufia.config.callback.run(:after_fixity_check_failure,
-                                file_set,
-                                checksum_audit_log: log)
+      CurationConcerns.config.callback.run(:after_fixity_check_failure,
+                                           file_set,
+                                           checksum_audit_log: log)
     end
 
     log

--- a/patches/fixity_checks/fixity_check_job.rb
+++ b/patches/fixity_checks/fixity_check_job.rb
@@ -1,0 +1,76 @@
+# Backported from https://github.com/projecthydra-labs/hyrax/pull/984
+# Expected in Hyrax 2.0
+if Gem.loaded_specs["hyrax"] && Gem.loaded_specs["hyrax"].version >= Gem::Version.new('2.0')
+  msg = "\n\nPlease check and make sure this fixity check patch is still needed at #{__FILE__}:#{__LINE__}\n\n"
+  $stderr.puts msg
+  Rails.logger.warn msg
+end
+
+class FixityCheckJob < ActiveJob::Base
+  # A Job class that runs a fixity check (using ActiveFedora::FixityService,
+  # which contacts fedora and requests a fixity check), and stores the results
+  # in an ActiveRecord ChecksumAuditLog row. It also prunes old ChecksumAuditLog
+  # rows after creating a new one, to keep old ones you don't care about from
+  # filling up your db.
+  #
+  # The uri passed in is a fedora URI that fedora can run fixity check on.
+  # It's normally a version URI like:
+  #     http://localhost:8983/fedora/rest/test/a/b/c/abcxyz/content/fcr:versions/version1
+  #
+  # But could theoretically be any URI fedora can fixity check on, like a file uri:
+  #     http://localhost:8983/fedora/rest/test/a/b/c/abcxyz/content
+  #
+  # The file_set_id and file_id are used only for logging context in the
+  # ChecksumAuditLog, and determining what old ChecksumAuditLogs can
+  # be pruned.
+  #
+  # If calling async as a background job, return value is irrelevant, but
+  # if calling sync with `perform_now`, returns the ChecksumAuditLog
+  # record recording the check.
+  #
+  # @param uri [String] uri - of the specific file/version to fixity check
+  # @param file_set_id [FileSet] the id for FileSet parent object of URI being checked.
+  # @param file_id [String] File#id, used for logging/reporting.
+  def perform(uri, file_set_id:, file_id:)
+    uri = uri.to_s # sometimes we get an RDF::URI gah
+    log = run_check(file_set_id, file_id, uri)
+
+    if log.failed? && Sufia.config.callback.set?(:after_fixity_check_failure)
+      file_set = ::FileSet.find(file_set_id)
+      Sufia.config.callback.run(:after_fixity_check_failure,
+                                file_set,
+                                checksum_audit_log: log)
+    end
+
+    log
+  end
+
+  protected
+
+    def run_check(file_set_id, file_id, uri)
+      service = ActiveFedora::FixityService.new(uri)
+      begin
+        fixity_ok = service.check
+        # only new versions of activefedora support returning this...
+        expected_result = service.expected_message_digest if service.respond_to?(:expected_message_digest)
+      rescue Ldp::NotFound
+        error_msg = 'resource not found'
+      end
+
+      log = ChecksumAuditLog.create!(passed: fixity_ok, file_set_id: file_set_id, checked_uri: uri, file_id: file_id, expected_result: expected_result)
+
+      if fixity_ok
+        ChecksumAuditLog.prune_history(file_set_id, checked_uri: uri)
+      else
+        logger.error "FIXITY CHECK FAILURE: Fixity failed for #{uri} #{error_msg}: #{log}"
+      end
+
+      log
+    end
+
+  private
+
+    def logger
+      ActiveFedora::Base.logger
+    end
+end

--- a/patches/fixity_checks/hyrax/file_set_fixity_check_service.rb
+++ b/patches/fixity_checks/hyrax/file_set_fixity_check_service.rb
@@ -1,0 +1,129 @@
+module Hyrax
+  # Backported from https://github.com/projecthydra-labs/hyrax/pull/984
+  # Expected in Hyrax 2.0
+  if Gem.loaded_specs["hyrax"] && Gem.loaded_specs["hyrax"].version >= Gem::Version.new('2.0')
+    msg = "\n\nPlease check and make sure this fixity check patch is still needed at #{__FILE__}:#{__LINE__}\n\n"
+    $stderr.puts msg
+    Rails.logger.warn msg
+  end
+  # This class runs fixity checks on a FileSet, potentially on multiple
+  # files each with multiple versions in the FileSet.
+  #
+  # The FixityCheck itself is performed by FixityCheckJob, which
+  # just uses the fedora service to ask for fixity verification.
+  # The outcome will be some created ChecksumAuditLog (ActiveRecord)
+  # objects, recording the checks and their results.
+  #
+  # By default this runs the checks async using ActiveJob, so
+  # returns no useful info -- the checks are still going on. Use
+  # FixityStatusService if you'd like a human-readable status based on
+  # latest recorded checks, or ChecksumAuditLog.latest_for_fileset_id
+  # if you'd like the the machine-readable checks.
+  #
+  # But if you initialize with `async_jobs: false`, checks will be done
+  # blocking in foreground, and you can get back the ChecksumAuditLog
+  # records created.
+  #
+  # It will only run fixity checks if there are not recent
+  # ChecksumAuditLogs on record. "recent" is defined by
+  # `max_days_between_fixity_checks` arg, which defaults to config'd
+  # `Hyrax.config.max_days_between_fixity_checks`
+  class FileSetFixityCheckService
+    attr_reader :file_set, :id, :latest_version_only,
+                :async_jobs, :max_days_between_fixity_checks
+
+    # @param file_set [ActiveFedora::Base, String] file_set
+    # @param async_jobs [Boolean] Run actual fixity checks in background. Default true.
+    # @param max_days_between_fixity_checks [int] if an exisitng fixity check is
+    #   recorded within this window, no new one will be created. Default
+    #   `Hyrax.config.max_days_between_fixity_checks`. Set to -1 to force
+    #    check.
+    # @param latest_version_only [Booelan]. Check only latest version instead of all
+    #   versions. Default false.
+    def initialize(file_set,
+                   async_jobs: true,
+                   max_days_between_fixity_checks: Sufia.config.max_days_between_audits,
+                   latest_version_only: false)
+      @max_days_between_fixity_checks = max_days_between_fixity_checks || 0
+      @async_jobs = async_jobs
+      @latest_version_only = latest_version_only
+      if file_set.is_a?(String)
+        @id = file_set
+      else
+        @id = file_set.id
+        @file_set = file_set
+      end
+    end
+
+    # Fixity checks each version of each file if it hasn't been checked recently
+    # If object async_jobs is false, will returns the set of most recent fixity check
+    # status for each version of the content file(s). As a hash keyed by file_id,
+    # values arrays of possibly multiple version checks.
+    #
+    # If async_jobs is true (default), just returns nil, stuff is still going on.
+    def fixity_check
+      results = file_set.files.collect { |f| fixity_check_file(f) }
+
+      return if async_jobs
+
+      results.flatten.group_by(&:file_id)
+    end
+
+    # Return current fixity status for this FileSet based on
+    # ChecksumAuditLog records on file.
+    def logged_fixity_status
+      Deprecation.warn(self, "logged_fixity_status is deprecated, use FixityStatusPresenter instead")
+      FixityStatusPresenter.new(file_set.id).render_file_set_status
+    end
+
+    private
+
+      # Retrieve or generate the fixity check for a file
+      # (all versions are checked for versioned files unless latest_version_only set)
+      # @param [ActiveFedora::File] file to fixity check
+      # @param [Array] log container for messages
+      def fixity_check_file(file)
+        versions = file.has_versions? ? file.versions.all : [file]
+
+        versions = [versions.max_by(&:created)] if latest_version_only
+
+        versions.collect { |v| fixity_check_file_version(file.id, v.uri.to_s) }.flatten
+      end
+
+      # Retrieve or generate the fixity check for a specific version of a file
+      # @param [String] file_id used to find the file within its parent object (usually "original_file")
+      # @param [String] version_uri the version to be fixity checked (or the file uri for non-versioned files)
+      def fixity_check_file_version(file_id, version_uri)
+        latest_fixity_check = ChecksumAuditLog.logs_for(file_set.id, checked_uri: version_uri).first
+        return latest_fixity_check unless needs_fixity_check?(latest_fixity_check)
+
+        if async_jobs
+          FixityCheckJob.perform_later(version_uri.to_s, file_set_id: file_set.id, file_id: file_id)
+        else
+          FixityCheckJob.perform_now(version_uri.to_s, file_set_id: file_set.id, file_id: file_id)
+        end
+      end
+
+      # Check if time since the last fixity check is greater than the maximum days allowed between fixity checks
+      # @param [ChecksumAuditLog] latest_fixity_check the most recent fixity check
+      def needs_fixity_check?(latest_fixity_check)
+        return true unless latest_fixity_check
+        unless latest_fixity_check.updated_at
+          logger.warn "***FIXITY*** problem with fixity check log! Latest Fixity check is not nil, but updated_at is not set #{latest_fixity_check}"
+          return true
+        end
+        days_since_last_fixity_check(latest_fixity_check) >= max_days_between_fixity_checks
+      end
+
+      # Return the number of days since the latest fixity check
+      # @param [ChecksumAuditLog] latest_fixity_check the most recent fixity check
+      def days_since_last_fixity_check(latest_fixity_check)
+        (DateTime.current - latest_fixity_check.updated_at.to_date).to_i
+      end
+
+      # Loads the FileSet from Fedora if needed
+      def file_set
+        @file_set ||= ::FileSet.find(id)
+      end
+  end
+end

--- a/patches/fixity_checks/hyrax/fixity_status_presenter.rb
+++ b/patches/fixity_checks/hyrax/fixity_status_presenter.rb
@@ -1,0 +1,97 @@
+# Backported from https://github.com/projecthydra-labs/hyrax/pull/984
+# Expected in Hyrax 2.0
+if Gem.loaded_specs["hyrax"] && Gem.loaded_specs["hyrax"].version >= Gem::Version.new('2.0')
+  msg = "\n\nPlease check and make sure this fixity check patch is still needed at #{__FILE__}:#{__LINE__}\n\n"
+  $stderr.puts msg
+  Rails.logger.warn msg
+end
+
+module Hyrax
+  # Creates fixity status messages to display to user, for a fileset.
+  # Determines status by looking up existing recorded ChecksumAuditLog objects,
+  # does not actually do a check itself.
+  #
+  # See FileSetFixityCheckService and ChecksumAuditLog for actually performing
+  # checks and recording as ChecksumAuditLog objects.
+  class FixityStatusPresenter
+    include ActionView::Helpers::TagHelper
+    include ActionView::Helpers::TextHelper
+    include ActionView::Helpers::OutputSafetyHelper
+
+    attr_reader :file_set_id, :relevant_log_records
+    # Note this takes a file_set_id NOT a FileSet, easy use from either solr
+    # or AF object.
+    def initialize(file_set_id)
+      @file_set_id = file_set_id
+    end
+
+    # Returns a html_safe string communicating fixity status checks,
+    # possibly on multiple files/versions.
+    def render_file_set_status
+      @file_set_status ||=
+        if relevant_log_records.empty?
+          "Fixity checks have not yet been run on this object"
+        elsif failing_checks.empty?
+          content_tag("span", "passed", class: "label label-success") + ' ' + render_existing_check_summary
+        else
+          content_tag("span", "FAIL", class: "label label-danger") + ' ' + render_existing_check_summary + render_failed_compact
+        end
+    end
+
+    protected
+
+      # A weird display, cause we need it to fit in that 180px column on
+      # FileSet show, and have no real UI to link to for files/versions :(
+      # rubocop:disable Metrics/MethodLength
+      def render_failed_compact
+        safe_join(
+          ["<p><strong>Failed checks:</strong></p>".html_safe] +
+          failing_checks.collect do |log|
+            safe_join(
+              [
+                "<p>".html_safe,
+                "ChecksumAuditLog id: #{log.id}; ",
+                content_tag("a", "file", href: "#{Hydra::PCDM::File.translate_id_to_uri.call(log.file_id)}/fcr:metadata") + "; ",
+                content_tag("a", "checked_uri", href: "#{log.checked_uri}/fcr:metadata") + "; ",
+                "date: #{log.created_at}; ",
+                "expected_result: #{log.expected_result}",
+                "</p>".html_safe
+              ]
+            )
+          end
+        )
+      end
+      # rubocop:enable Metrics/MethodLength
+
+      def render_existing_check_summary
+        @render_existing_check_summary ||=
+          "#{pluralize num_checked_files, 'File'} with #{pluralize relevant_log_records.count, 'total version'} checked #{render_date_range}"
+      end
+
+      def render_date_range
+        @render_date_range ||= begin
+          from = relevant_log_records.min_by(&:created_at).created_at.to_s
+          to   = relevant_log_records.max_by(&:created_at).created_at.to_s
+          if from == to
+            from
+          else
+            "between #{from} and #{to}"
+          end
+        end
+      end
+
+      # Should be all _latest_ ChecksumAuditLog about different files/versions
+      # currently existing in specified FileSet.
+      def relevant_log_records
+        @relevant_log_records = ChecksumAuditLog.latest_for_file_set_id(file_set_id)
+      end
+
+      def num_checked_files
+        @num_relevant_files ||= relevant_log_records.group_by(&:file_id).keys.count
+      end
+
+      def failing_checks
+        @failing_checks ||= relevant_log_records.find_all(&:failed?)
+      end
+  end
+end

--- a/spec/factories/file_set.rb
+++ b/spec/factories/file_set.rb
@@ -3,9 +3,17 @@ FactoryGirl.define do
   factory :file_set do
     transient do
       user { FactoryGirl.create(:user) }
+      content nil
     end
+
     after(:build) do |fs, evaluator|
       fs.apply_depositor_metadata evaluator.user.user_key
+    end
+
+    after(:create) do |file, evaluator|
+      if evaluator.content
+        Hydra::Works::UploadFileToFileSet.call(file, evaluator.content)
+      end
     end
 
     trait :public do

--- a/spec/services/hyrax/file_set_fixity_check_service_spec.rb
+++ b/spec/services/hyrax/file_set_fixity_check_service_spec.rb
@@ -45,7 +45,7 @@ describe Hyrax::FileSetFixityCheckService do
       expect(last_email.body.to_s).to include(checked_uri)
       expect(last_email.body.to_s).to include(expected_message_digest)
       expect(last_email.body.to_s).to include(log.created_at.in_time_zone.to_s)
-      expect(last_email.body.to_s).to include("<ChecksumAuditLog id: #{log.id}")
+      expect(last_email.body.to_s).to include("ChecksumAuditLog id: #{log.id}")
     end
   end
 end

--- a/spec/services/hyrax/file_set_fixity_check_service_spec.rb
+++ b/spec/services/hyrax/file_set_fixity_check_service_spec.rb
@@ -1,0 +1,51 @@
+require 'spec_helper'
+
+# Testing our backported Hyrax::FileSetFixityCheckService, but
+# also testing that our customized "failure" hook is called, so
+# spec probably of use even after our backport is removed.
+#
+# Sort of a high-level integration-type spec, in that it intentionally
+# exersizes a bunch of classes at once, only mocking the actual fedora
+# response. Sorry, there's plusses and minuses.
+describe Hyrax::FileSetFixityCheckService do
+  context "fixity failure" do
+    let(:file_set) { FactoryGirl.create(:file_set, title: ["sample.jpg"], content: StringIO.new("adfadf")) }
+    let(:file_id) { file_set.original_file.id }
+    let(:checked_uri) { file_set.original_file.versions.last.uri }
+
+    let(:service) { Hyrax::FileSetFixityCheckService.new(file_set, async_jobs: false) }
+    let(:expected_message_digest) { "urn:sha1:8557baf29574415034f41ce2cc3e65f55faf937e" }
+    let(:mock_fedora_service) { double('mock fixity check service') }
+
+    before do
+      allow(ActiveFedora::FixityService).to receive(:new).and_return(mock_fedora_service)
+      allow(mock_fedora_service).to receive(:check).and_return(false)
+      allow(mock_fedora_service).to receive(:expected_message_digest).and_return(expected_message_digest)
+    end
+
+    it "creates log and notifies" do
+      service.fixity_check
+
+      expect(ChecksumAuditLog.count).to eq 1
+      log = ChecksumAuditLog.first
+      expect(log.file_set_id).to eq file_set.id
+      expect(log.file_id).to eq file_id
+      expect(log.checked_uri).to eq checked_uri
+      expect(log.expected_result).to eq expected_message_digest
+      expect(log.passed?).to be false
+
+      expect(ActionMailer::Base.deliveries.count).to eq(1)
+      last_email = ActionMailer::Base.deliveries.last
+
+      expect(last_email.to).to eq(["digital-tech@chemheritage.org"])
+      expect(last_email.from).to eq(["digital-tech@chemheritage.org"])
+      expect(last_email.subject).to eq("FIXITY CHECK FAILURE: sample.jpg")
+      expect(last_email.body.to_s).to include(file_set.id)
+      expect(last_email.body.to_s).to include(file_id)
+      expect(last_email.body.to_s).to include(checked_uri)
+      expect(last_email.body.to_s).to include(expected_message_digest)
+      expect(last_email.body.to_s).to include(log.created_at.in_time_zone.to_s)
+      expect(last_email.body.to_s).to include("<ChecksumAuditLog id: #{log.id}")
+    end
+  end
+end


### PR DESCRIPTION
Backported code that I previously contributed to Hyrax. 

May handle #276?

The backport was a bit messy. I tried a new way to organize this code -- a folder at `./app/patches`, that can have subdirs, which have a README describing what they're doing, and include files needed for one conceptual patch or backport.  Added `Dir.glob(Rails.root.join("patches/*"))` to Rails `autoload_paths` to accomplish this. 

This code organization definitely doesn't completely eliminate the pain of dealing with this in the future as we upgrade our dependencies, but it's the best I could come up with. 

What this actually does:

Every day at 2:30am, a fixity check rake task is run. 
* While it runs every day, it currently is set to accept up to 7-day-old existing fixity checks, so won't always re-check everything. (configurable)
* It is currently set to only check current versions, not all versions (configurable)
* It avoids using the ActiveJob queue, it just does everything in-process.  
* (Note that if we scale out rails servers, we'll have to make sure these cronjobs scheduled by whenever are only run on _one_ server, not every server)

If a fixity failure is found, it will send a notification to: email to `digital-tech@chemheritage.org`; and an in-message notification to anyone with `admin` role. 

The failure notifications are not pretty, they're kind of just a tech dump of all the relevant objects involved, meant for consumption by technical staff. I don't expect to get a fixity failure notification often. An example notification:

~~~
Subject: FIXITY CHECK FAILURE: sample.jpg

hostname: macbook

Fixity check failure at 2017-05-23 15:28:28 UTC
for: http://127.0.0.1:8080/rest/dev/bv/73/c0/41/bv73c041b/files/3183d6ac-1593-4765-95ed-9769de5bc938/fcr:versions/version1/fcr:metadata

Expected fixity result: urn:sha1:be79efcdd7562cef06a393de04188ca09cb21724

work: additional title tests 8049g504g /concern/generic_works/8049g504g

file_set: bv73c041b sample.jpg /concern/file_sets/8049g504g.bv73c041b http://127.0.0.1:8080/rest/dev/bv/73/c0/41/bv73c041b/fcr:metadata

file: bv73c041b/files/3183d6ac-1593-4765-95ed-9769de5bc938 http://127.0.0.1:8080/rest/dev/bv/73/c0/41/bv73c041b/files/3183d6ac-1593-4765-95ed-9769de5bc938/fcr:metadata

Logged in ChecksumAuditLog: #<ChecksumAuditLog id: 36, file_set_id: "bv73c041b", file_id: "bv73c041b/files/3183d6ac-1593-4765-95ed-9769de5bc9...", checked_uri: "http://127.0.0.1:8080/rest/dev/bv/73/c0/41/bv73c04...", passed: false, expected_result: "urn:sha1:be79efcdd7562cef06a393de04188ca09cb21724", actual_result: nil, created_at: "2017-05-23 15:28:28", updated_at: "2017-05-23 15:28:28">
~~~

Additionally, the 'fixity status' line on a FileSet show page now does show actual fixity status, although the display again isn't pretty. 