### PR TITLE
/login works as sign_in path

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,6 +24,11 @@ Rails.application.routes.draw do
   end
 
   devise_for :users
+  # https://github.com/plataformatec/devise/wiki/how-to:-change-the-default-sign_in-and-sign_out-routes
+  devise_scope :user do
+    get 'login', to: 'devise/sessions#new'
+  end
+
   resources :welcome, only: 'index'
   root 'sufia/homepage#index'
   curation_concerns_collections


### PR DESCRIPTION
This is one way to get it to work anyway.
/users/sign_in still works too. Not sure which will be used for internal route-generating.

We can fine-tune this later, but this at least gets /login working so we can
announce the new hostname URL with the easier path at the same time.