### PR TITLE
Image viewer

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -49,6 +49,8 @@ gem 'jbuilder', '~> 2.0'
 # bundle exec rake doc:rails generates the API under doc/api.
 gem 'sdoc', '~> 0.4.0', group: :doc
 
+gem 'openseadragon'
+
 source 'https://rails-assets.org' do
   gem 'rails-assets-lazysizes'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -823,6 +823,7 @@ DEPENDENCIES
   jettywrapper
   jquery-rails
   oauth2 (= 1.2.0)
+  openseadragon
   pg
   phantomjs (~> 2.1.1)
   poltergeist (~> 1.5)

--- a/app/assets/javascripts/chf_ga_events.js
+++ b/app/assets/javascripts/chf_ga_events.js
@@ -1,0 +1,14 @@
+// Sufia/hyrax JS for sending event tracking to Google Analytics is a bit inflexible.
+// https://github.com/samvera/hyrax/blob/1e504c200fd9c39120f514ac33cd42cd843de9fa/app/assets/javascripts/hyrax/ga_events.js
+//
+// We add our own more flexible.
+//
+// https://developers.google.com/analytics/devguides/collection/gajs/eventTrackerGuide
+
+$(document).on('click', '*[data-analytics-event]', function(e) {
+  _gaq.push(['_trackEvent',
+             e.target.getAttribute("data-analytics-event"),
+             e.target.getAttribute("data-analytics-label"),
+             e.target.getAttribute("data-analytics-value")
+            ]);
+});

--- a/app/assets/javascripts/chf_image_viewer.js
+++ b/app/assets/javascripts/chf_image_viewer.js
@@ -1,0 +1,497 @@
+// A JS 'class' for dealing with the image viewer
+
+function ChfImageViewer(element) {
+  this.element = element;
+  this.initModal(document.querySelector("#chf-image-viewer-modal"));
+}
+
+ChfImageViewer.prototype.viewerPathComponentRe = /\/viewer\/(\w+)$/;
+
+ChfImageViewer.prototype.show = function(id) {
+  if (document.activeElement && document.activeElement.getAttribute("data-trigger") == "chf_image_viewer") {
+    this.previousFocus = document.activeElement;
+  }
+
+  if (typeof this.viewer == "undefined") {
+    this.initOpenSeadragon();
+  }
+
+  this.totalCount = parseInt(document.querySelector(".viewer-thumbs[data-total-count]").getAttribute("data-total-count"));
+  if (this.totalCount == 1) {
+    // hide multi-item-relevant controls
+    document.querySelector("#viewer-pagination").style.display = "none";
+    document.querySelector("#viewer-right").style.display = "none";
+    document.querySelector("#viewer-left").style.display = "none";
+    document.querySelector("#viewer-thumbs").style.display = "none";
+  }
+
+  if (! OpenSeadragon.supportsFullScreen) {
+    document.querySelector("#viewer-fullscreen").style.display = "none";
+  }
+  if (! this.viewer.drawer.canRotate()) {
+    //OSD says no rotate
+    document.querySelector("#viewer-rotate-right").style.display = "none";
+  }
+
+  var selectedThumb;
+  // find the thumb
+  if (id) {
+    selectedThumb = document.querySelector(".viewer-thumb-img[data-member-id='" + id + "']");
+  }
+  if (! selectedThumb) {
+    // just use the first one
+    selectedThumb = document.querySelector(".viewer-thumb-img");
+  }
+  this.selectThumb(selectedThumb);
+
+  // show the viewer
+  $(this.modal).modal("show");
+  this.scrollSelectedIntoView();
+};
+
+// position can be 'start', 'end'
+ChfImageViewer.prototype.scrollSelectedIntoView = function(position) {
+  // only if the selected thing is not currently in scroll view, scroll
+  // it to be so.
+  // https://stackoverflow.com/a/16309126/307106
+
+  var elem = this.selectedThumb;
+
+  var container = $(".viewer-thumbs");
+
+  var contHeight = container.height();
+  var contTop = container.scrollTop();
+  var contBottom = contTop + contHeight ;
+
+  var contWidth = container.width();
+  var contLeft = container.scrollLeft();
+  var contRight = contLeft + contWidth;
+
+
+  var elemTop = $(elem).offset().top - container.offset().top;
+  var elemBottom = elemTop + $(elem).height();
+  var elemLeft = $(elem).offset().left - container.offset().left;
+  var elemRight = elemLeft + $(elem).width();
+
+  var isTotal = (elemTop >= 0 && elemBottom <= contHeight && elemLeft >= 0 && elemRight <= contWidth);
+
+  if (! isTotal) {
+    if (position == "end") {
+      this.selectedThumb.scrollIntoView(false);
+    } else {
+      this.selectedThumb.scrollIntoView();
+    }
+  }
+}
+
+ChfImageViewer.prototype.hide = function() {
+  if (OpenSeadragon.isFullScreen()) {
+    OpenSeadragon.exitFullScreen();
+  }
+  $(this.modal).modal("hide");
+  this.removeLocationUrl();
+  this.restoreFocus();
+};
+
+
+ChfImageViewer.prototype.restoreFocus =  function() {
+  if(this.previousFocus) {
+    this.previousFocus.focus();
+    this.previousFocus = undefined;
+  }
+};
+
+ChfImageViewer.prototype.removeLoading =  function(viewer) {
+  $('.viewer-image').removeClass('viewer-image-loading');
+};
+
+ChfImageViewer.prototype.id2TileSource = function(id) {
+  return {
+    type: 'image',
+    url: '/downloads/' + id + "?file=jpeg"
+  };
+}
+
+ChfImageViewer.prototype.selectThumb = function(thumbElement) {
+  this.selectedThumb = thumbElement;
+
+  // toggle classes, sorry some jQuery
+  $('.viewer-thumbs .viewer-thumb-selected').removeClass('viewer-thumb-selected')
+  thumbElement.classList.add('viewer-thumb-selected');
+
+  var id    = thumbElement.getAttribute('data-member-id');
+  var index = thumbElement.getAttribute('data-index');
+  var shouldShowInfo = thumbElement.getAttribute('data-member-should-show-info') == "true";
+  var title = thumbElement.getAttribute('data-title');
+  var linkUrl   = thumbElement.getAttribute('data-member-show-url');
+
+  $('.viewer-image').addClass('viewer-image-loading');
+
+  this.viewer.open(this.id2TileSource(id));
+
+  document.querySelector('*[data-hook="viewer-navbar-title-label"]').textContent = title;
+  document.querySelector('*[data-hook="viewer-navbar-info-link"]').href = linkUrl;
+  document.getElementsByClassName('viewer-pagination-numerator').item(0).textContent = index;
+
+  if (shouldShowInfo) {
+    // spacer shows up when info doesn't.
+    document.querySelector('#viewer-member-info').style.display = "";
+    document.querySelector('#viewer-spacer').style.display = "none";
+  } else {
+    document.querySelector('#viewer-member-info').style.display = "none";
+    document.querySelector('#viewer-spacer').style.display = "";
+  }
+
+  // show/hide next/prev as appropriate
+  if (index <= 1) {
+    document.querySelector("#viewer-left").style.display = "none";
+  } else if ( this.totalCount != 1 ) {
+    document.querySelector("#viewer-left").style.display = "";
+  }
+
+  if (index >= this.totalCount) {
+    document.querySelector("#viewer-right").style.display = "none";
+  } else if ( this.totalCount != 1 ) {
+    document.querySelector("#viewer-right").style.display = "";
+  }
+
+  this.setLocationUrl();
+};
+
+ChfImageViewer.prototype.next = function() {
+  var nextElement = this.selectedThumb.nextElementSibling;
+  if (nextElement) {
+    this.selectThumb(nextElement);
+    this.scrollSelectedIntoView("start");
+  }
+};
+
+ChfImageViewer.prototype.prev = function() {
+  var prevElement = this.selectedThumb.previousElementSibling;
+  if (prevElement) {
+    this.selectThumb(prevElement);
+    this.scrollSelectedIntoView("end");
+  }
+};
+
+ChfImageViewer.prototype.setLocationUrl = function() {
+  var currentPath = location.pathname;
+  var selectedID = this.selectedThumb.getAttribute('data-member-id');
+
+  var newPath;
+
+  if (currentPath.match(this.viewerPathComponentRe)) {
+    newPath = currentPath.replace(this.viewerPathComponentRe, '/viewer/' + encodeURIComponent(selectedID));
+  } else if (currentPath.match(/\/$/)) {
+    newPath = currentPath + 'viewer/' + encodeURIComponent(selectedID);
+  } else {
+    newPath = currentPath + '/viewer/' + encodeURIComponent(selectedID);
+  }
+
+  history.replaceState({}, "", this.locationWithNewPath(newPath));
+};
+
+ChfImageViewer.prototype.removeLocationUrl = function() {
+  if (location.pathname.match(this.viewerPathComponentRe)) {
+    var newPath = location.pathname.replace(this.viewerPathComponentRe, '');
+    history.replaceState({}, "", this.locationWithNewPath(newPath));
+  }
+}
+
+ChfImageViewer.prototype.locationWithNewPath = function(newPath) {
+  var newUrl = location.protocol + '//' + location.host + newPath;
+  if (location.query) {
+    newUrl += '?' + location.query;
+  }
+  if (location.hash) {
+    newUrl += '#' + location.hash;
+  }
+  return newUrl;
+};
+
+ChfImageViewer.prototype.onKeyDown = function(event) {
+  if (this.dropdownVisible) {
+    return;
+  }
+
+  // Many parts copied/modified from OSD source, no way to proxy to it directly.
+  // This one expects a jQuery event.
+  // And has a couple custom mappings added to it.
+  // https://github.com/openseadragon/openseadragon/blob/e81e30c81cd8be566a4c8011ad7f592ac1df30d3/src/viewer.js#L2414-L2499
+  if ( !event.preventDefaultAction && !event.ctrl && !event.alt && !event.meta ) {
+      switch( event.keyCode ){
+          case 27: // ESC
+            this.hide();
+            return false;
+          case 38://up arrow
+              if ( event.shiftKey ) {
+                  this.viewer.viewport.zoomBy(1.1);
+              } else {
+                  this.viewer.viewport.panBy(this.viewer.viewport.deltaPointsFromPixels(new OpenSeadragon.Point(0, -40)));
+              }
+              this.viewer.viewport.applyConstraints();
+              return false;
+          case 40://down arrow
+              if ( event.shiftKey ) {
+                  this.viewer.viewport.zoomBy(0.9);
+              } else {
+                  this.viewer.viewport.panBy(this.viewer.viewport.deltaPointsFromPixels(new OpenSeadragon.Point(0, 40)));
+              }
+              this.viewer.viewport.applyConstraints();
+              return false;
+          case 37://left arrow
+              if (event.shiftKey) {
+                // custom CHF, next doc
+                this.prev();
+                return false;
+              } else {
+                this.viewer.viewport.panBy(this.viewer.viewport.deltaPointsFromPixels(new OpenSeadragon.Point(-40, 0)));
+                this.viewer.viewport.applyConstraints();
+                return false;
+              }
+          case 39://right arrow
+            if (event.shiftKey) {
+              // custom CHF, prev doc
+              this.next();
+              return false;
+            } else {
+              this.viewer.viewport.panBy(this.viewer.viewport.deltaPointsFromPixels(new OpenSeadragon.Point(40, 0)));
+              this.viewer.viewport.applyConstraints();
+              return false;
+            }
+          default:
+              //console.log( 'navigator keycode %s', event.keyCode );
+              return true;
+      }
+  } else {
+      return true;
+  }
+}
+
+ChfImageViewer.prototype.onKeyPress = function(event) {
+  if (this.dropdownVisible) {
+    return;
+  }
+
+  // Many parts copied/modified from OSD source, no way to proxy to it directly.
+  // This one expects a jQuery event.
+  // https://github.com/openseadragon/openseadragon/blob/e81e30c81cd8be566a4c8011ad7f592ac1df30d3/src/viewer.js#L2414-L2499
+  if ( !event.preventDefaultAction && !event.ctrlKey && !event.altKey && !event.metaKey ) {
+        switch( event.which ){
+          case 46: //.|>
+          case 62: //.|>
+            this.next();
+            return false;
+          case 44: //,|<
+          case 50: //,|<
+            this.prev();
+            return false;
+          case 43://=|+
+          case 61://=|+
+              this.viewer.viewport.zoomBy(1.1);
+              this.viewer.viewport.applyConstraints();
+              return false;
+          case 45://-|_
+              this.viewer.viewport.zoomBy(0.9);
+              this.viewer.viewport.applyConstraints();
+              return false;
+          case 48://0|)
+              this.viewer.viewport.goHome();
+              this.viewer.viewport.applyConstraints();
+              return false;
+          case 119://w
+          case 87://W
+              if ( event.shiftKey ) {
+                  this.viewer.viewport.zoomBy(1.1);
+              } else {
+                  this.viewer.viewport.panBy(this.viewer.viewport.deltaPointsFromPixels(new OpenSeadragon.Point(0, -40)));
+              }
+              this.viewer.viewport.applyConstraints();
+              return false;
+          case 115://s
+          case 83://S
+              if ( event.shiftKey ) {
+                  this.viewer.viewport.zoomBy(0.9);
+              } else {
+                  this.viewer.viewport.panBy(this.viewer.viewport.deltaPointsFromPixels(new OpenSeadragon.Point(0, 40)));
+              }
+              this.viewer.viewport.applyConstraints();
+              return false;
+          case 97://a
+              this.viewer.viewport.panBy(this.viewer.viewport.deltaPointsFromPixels(new OpenSeadragon.Point(-40, 0)));
+              this.viewer.viewport.applyConstraints();
+              return false;
+          case 100://d
+              this.viewer.viewport.panBy(this.viewer.viewport.deltaPointsFromPixels(new OpenSeadragon.Point(40, 0)));
+              this.viewer.viewport.applyConstraints();
+              return false;
+          default:
+              //console.log( 'navigator keycode %s', event.keyCode );
+              return true;
+        }
+    } else {
+        return true;
+    }
+};
+
+
+// We use the bootstrap modal, because it already handles
+// tricky issues of full-body scroll and tabindex. We need to
+// restyle some of it in CSS to be full-screen.
+ChfImageViewer.prototype.initModal = function(modalElement) {
+  this.modal = modalElement;
+  this.modal = $(this.modal).modal({
+    show: false,
+    keyboard: false
+  });
+};
+
+ChfImageViewer.prototype.initOpenSeadragon = function() {
+  // we only want a rotate-right, not rotate-left. Can't figure
+  // out how to get OSD to do that, and not try to fetch rotate-left
+  // images, except giving it a fake rotate-left
+  // button, sorry!
+  var dummyRotateLeft = document.createElement("div");
+  dummyRotateLeft.id ='dummy-osd-rotate-left';
+  dummyRotateLeft.style.display = 'none';
+  document.body.appendChild(dummyRotateLeft);
+
+  this.viewer = OpenSeadragon({
+    id:            'openseadragon-container',
+    showRotationControl: true,
+    showFullPageControl: false,
+
+    // we use our own controls
+    zoomInButton:       "viewer-zoom-in",
+    zoomOutButton:      "viewer-zoom-out",
+    homeButton:         "viewer-zoom-fit",
+    rotateRightButton:  "viewer-rotate-right",
+    rotateLeftButton:   "dummy-osd-rotate-left",
+
+    tabIndex: "",
+
+    gestureSettingsTouch: {
+      pinchRotate: true
+    }
+  });
+
+  // OSD seems to insist on setting inline style position:relative on it's
+  // own container. If we just change that to 'absolute', then it properly fills
+  // the space of it's container on our page the way we want it to. There
+  // must be a better way to do this, sorry for the hack.
+  this.viewer.container.style.position = "absolute";
+
+  this.viewer.addHandler("open", this.removeLoading);
+};
+
+
+
+jQuery(document).ready(function($) {
+  var viewerElement = document.getElementById('chf-image-viewer');
+
+  if (viewerElement) {
+    // lazily create a single page-wide ChfImageViewer helper
+    var _chf_image_viewer;
+    var chf_image_viewer = function() {
+      if (typeof _chf_image_viewer == 'undefined') {
+        _chf_image_viewer = new ChfImageViewer(viewerElement);
+      }
+
+      return _chf_image_viewer;
+    };
+
+    var viewerUrlMatch = ChfImageViewer.prototype.viewerPathComponentRe.exec(location.pathname);
+    if (viewerUrlMatch != null) {
+      // we have a viewer thumb in URL, let's load the viewer on page load!
+      chf_image_viewer().show(viewerUrlMatch[1]);
+    }
+
+    $(chf_image_viewer().modal).on("keypress.chf_image_viewer", function(event) {
+      chf_image_viewer().onKeyPress(event);
+    });
+    $(chf_image_viewer().modal).on("keydown.chf_image_viewer", function(event) {
+      chf_image_viewer().onKeyDown(event);
+    });
+    // Record whether dropdown is showing, so we can avoid keyboard handling
+    // for viewer when it is, let the dropdown have it. Prob better to
+    // do this with jquery on/off, but this was easiest for now.
+    $(chf_image_viewer().modal).on("show.bs.dropdown", function(event) {
+      chf_image_viewer().dropdownVisible = true;
+    });
+    $(chf_image_viewer().modal).on("hide.bs.dropdown", function(event) {
+      chf_image_viewer().dropdownVisible = false;
+    });
+
+    $(document).on("click", "*[data-trigger='chf_image_viewer']", function(event) {
+      event.preventDefault();
+      var id = this.getAttribute('data-member-id');
+      chf_image_viewer().show(id);
+
+      // GA
+      _gaq.push(['_trackEvent',
+           'ImageViewer',
+           'fileSetId',
+           id
+          ]);
+    });
+
+    // with keyboard-tab nav to our thumbs, let return/space trigger click as for normal links
+    $(document).on("keydown", "*[data-trigger='chf_image_viewer']", function(event) {
+      // space or enter trigger click for keyboard control
+      if (event.which == 13 || event.which == 32) {
+        event.preventDefault();
+        $(this).trigger("click");
+      }
+    });
+
+    // keyboard-tab and clicks on the overlay controls within thumb should
+    // not propagate to click on thumb itself!  Keyboard-tav return/space
+    // should trigger what the buttons do though.
+    $(document).on("keydown keypress click", ".show-page-image-bar button, .show-page-image-bar a", function(event) {
+      if (event.type == "click") {
+        event.stopPropagation();
+      } else if (event.which == 13 || event.which == 32) { // space or return
+        event.stopPropagation();
+        $(this).trigger("click");
+      }
+    });
+
+
+    $(document).on("click", "*[data-trigger='chf_image_viewer_close']", function(event) {
+      event.preventDefault();
+      chf_image_viewer().hide();
+    });
+
+    $(document).on("click", "*[data-trigger='change-viewer-source']", function(event) {
+      event.preventDefault();
+      chf_image_viewer().selectThumb(this);
+    });
+
+    $(document).on("keypress", "*[data-trigger='change-viewer-source']", function(event) {
+      // space or enter trigger click for keyboard control
+      if (event.which == 13 || event.which == 32) {
+        event.preventDefault();
+        $(this).trigger("click");
+      }
+    });
+
+    $(document).on("click", "*[data-trigger='viewer-next']", function(event) {
+      event.stopPropagation();
+      chf_image_viewer().next();
+    });
+
+    $(document).on("click", "*[data-trigger='viewer-prev']", function(event) {
+      event.stopPropagation();
+      chf_image_viewer().prev();
+    });
+
+    $(document).on("click", "*[data-trigger='viewer-fullscreen']", function(event) {
+      // Use OSD's cross-browser fullscreen implementation, great.
+      if (OpenSeadragon.isFullScreen()) {
+        OpenSeadragon.exitFullScreen();
+      } else {
+        OpenSeadragon.requestFullScreen( document.body );
+      }
+    });
+  }
+});

--- a/app/assets/stylesheets/local/chf_image_viewer.scss
+++ b/app/assets/stylesheets/local/chf_image_viewer.scss
@@ -1,0 +1,336 @@
+/*
+    The image viewer is a collection of nested flex divs -- inside a bootstrap
+    modal which has CSS overridden to be full-screen
+
+    #chf-image-viewer-modal .modal
+      .modal-dialog
+        .modal-content
+          .modal-body // this and above is standard bootstrap markup for modal
+
+            .chf-image-viewer
+              .viewer-header
+              .viewer-content
+                .viewer-image-and-navbar // to keep image and navbar together whether thumbs are on bottom or side
+                  .viewer-image
+                  .viewer-navbar
+                .viewer-thumbs
+
+    Divs that are in the middle of the hieararchy might be flex-items and
+    have CSS properties relevant to that, AND be `display:flex` for their
+    contents and have CSS properties relevant to that too.
+*/
+
+// Override some bootstrap modal stuff to give us a full-viewport modal
+#chf-image-viewer-modal {
+  .modal-dialog {
+    position: fixed;
+    height: 100%;
+    width: 100%;
+    margin: 0;
+    padding: 0;
+    border: 0;
+  }
+  .modal-content {
+    border: 0 none;
+    border-radius: 0;
+  }
+
+  // custom slide-up animation on open, no fade.
+  .modal-dialog {
+    top: 100vh;
+    bottom: 200vh;
+    transition-property: top, bottom;
+    transition-duration: 0.5s;
+    transition-timing-function: ease-in-out;
+  }
+  &.in .modal-dialog {
+    top: 0;
+    bottom: 100vh;
+  }
+}
+
+// Now styles for our actual viewer, which happens to be inside a bootstrap modal.
+.chf-image-viewer {
+  //cover whole screen. not totally sure why we need to repeat this
+  //when wrapping modal-dialog is already, but it works.
+  position: fixed;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  right: 0;
+  max-width: 100vw;
+
+  background-color: $body-bg;
+
+  display: flex;
+  flex-direction: column;
+
+  .viewer-header {
+    flex-shrink: 0;
+    background-color: $brand-inverse;
+    color: $brand-primary;
+    a {
+      color: $brand-primary;
+      &:hover {
+        color: white;
+      }
+    }
+
+    display: flex;
+    align-items: center;
+    padding: 4px 15px;
+
+    .chf-logo {
+      width: 50px;
+    }
+
+    h1 {
+      flex-grow: 1;
+
+      padding: 0;
+      margin: 0 15px;
+
+      font-size: $font-size-h3;
+
+      overflow: hidden;
+
+      a {
+        display: block;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
+    }
+    .header-close {
+      color: white;
+      font-size: $font-size-h3;
+    }
+  }
+
+  .viewer-content {
+    // as a mmeber of it's container flex
+    flex-grow: 1;
+
+    // and a flex itself with content
+    display: flex;
+    flex-direction: column;
+  }
+
+  .viewer-image-and-navbar {
+    // https://css-tricks.com/flexbox-truncated-text/
+    min-width: 0;
+    width: 100vw; // important to keep long child texts from overflowing on IE11
+    // as a member of it's container flex
+    flex-grow: 1;
+
+    // as a flex itself with content
+    display: flex;
+    flex-direction: column;
+
+    // the actual button link is full screen height for click target,
+    // but you can only see the <i> centered inside it. styles copied/adapted
+    // from bootstrap3 button-variant mixin, but only applying to <i> inside.
+    .viewer-image-next, .viewer-image-prev {
+      display: block;
+      z-index: 1; // above OSD canvas
+      position: absolute;
+      height: 100%;
+      cursor: pointer;
+      border: 0 none;
+      background: transparent;
+      padding: 0;
+
+      &:focus {
+        outline: 0;
+        i {
+          @include tab-focus;
+        }
+      }
+
+      &:hover {
+        i {
+          background-color: transparentize(darken($btn-primary-bg, 10%), .3);
+          border-color: darken($btn-primary-border, 12%);
+        }
+      }
+
+      & > i {
+        font-size: 2.5rem;
+        padding: 8px 12px;
+        background-color: transparentize($brand-inverse, .3);
+        border: 1px solid transparent;
+        border-radius: 40px;
+        color: white;
+        margin: 0 3px;
+      }
+    }
+    .viewer-image-next {
+      right: 0;
+      & > i {
+        padding-right: 9px;
+      }
+    }
+
+    .viewer-image-prev {
+      left: 0;
+      & > i {
+        padding-left: 9px;
+      }
+    }
+
+    .viewer-image {
+      flex-grow: 1;
+      // to be a anchor point for openseadragon viewer inside
+      position: relative;
+    }
+
+    .viewer-image.viewer-image-loading {
+      background: asset-url('spinner.svg') no-repeat center;
+      background-size: 25vw
+    }
+
+    // will show at larger sizes
+    .viewer-navbar-label {
+      display: none;
+    }
+
+    .viewer-navbar {
+      // bootstrap btn-justified doens't seem to be working, and flex is
+      // more powerful anyway.
+      display: flex;
+
+      .viewer-navbar-btn {
+        border-radius: 0 !important;
+        flex-grow: 2;
+      }
+      .viewer-thin-btn {
+        flex-grow: 0;
+      }
+      .btn-group .btn {
+        width: 100%;
+      }
+      .viewer-pagination {
+        flex-grow: 0;
+
+        background-color: $brand-inverse;
+        color: white;
+
+        font-weight: $btn-font-weight;
+        text-align: center;
+        vertical-align: middle;
+        @include button-size($padding-large-vertical, $padding-large-horizontal, $font-size-large, $line-height-large, 0);
+
+        white-space: nowrap;
+      }
+      .viewer-member-info {
+
+        @include button-size($padding-large-vertical, $padding-large-horizontal, $font-size-large, $line-height-large, 0);
+        border: 1px solid $btn-primary-border;
+        flex-grow: 4;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        text-align: left;
+      }
+      .viewer-spacer {
+        width: 0;
+        flex-grow: 1;
+        background-color: $brand-inverse;
+      }
+      .viewer-download {
+        max-width: 440px;
+      }
+      .viewer-keyboard {
+        .table {
+          margin-bottom: 0;
+        }
+        .dropdown-menu {
+          left: auto;
+          right: 5px;
+
+          min-width: 280px;
+          padding: 5px;
+
+          h3 {
+            margin-top: 0;
+            text-align: center;
+          }
+        }
+      }
+    }
+  }
+
+
+  $thumbSelectedColor: #f15c2b; // used on Distillations website, perhaps use as an alterante highlight sitewide
+
+  // single row with horizontal scrolling
+  .viewer-thumbs {
+    white-space: nowrap;
+    overflow-x: auto;
+    background-color: $brand-inverse;
+    padding: 7px;
+    max-height: 100%; // IE 11 needs this, although others don't, i dunno.
+
+    .viewer-thumb-img {
+      height: 80px;
+      max-width: 240px;
+
+      cursor: pointer;
+
+      // leave transparent space for selected border
+      border: 2px solid transparent;
+      padding: 1px;
+
+      &.viewer-thumb-selected {
+        border: 2px solid $thumbSelectedColor;
+      }
+
+      &.lazyload, &.lazyloading, &.lazyload {
+        background: #AAA asset-url('spinner.svg') no-repeat center;
+        background-size: 34px 34px;
+        width: 60px;
+        height: 80px;
+      }
+    }
+  }
+
+  // At larger screen sizes, thumbs go to a sidebar with multiple columns
+  @media (min-width: $screen-sm-min) {
+    // sorry the selectors get crazy unpredictable to ensure specificity
+    // for override. needs refactor.
+
+    .viewer-thumbs {
+      padding-top: 0;
+    }
+
+    .viewer-content {
+      flex-direction: row;
+      // don't totally understand this, but it gets our flex-in-flex layout
+      // right on FF, without the thumbs overflowing their bounding.
+      // https://bugzilla.mozilla.org/show_bug.cgi?id=1108514
+      min-height: 0;
+    }
+
+    .viewer-thumbs {
+      white-space: normal;
+      overflow-y: auto;
+      overflow-x: hidden;
+      // need to leave enough room for scroll-bar on browsers that count that inside
+      width: calc(60px * 2 + 7px * 3 + 1em);
+      flex-shrink: 0;
+
+      .viewer-thumb-img {
+        height: auto;
+        max-width: none;
+        width: 60px;
+        max-height: 120px;
+      }
+    }
+    .viewer-download {
+      flex-grow: 0;
+    }
+    .viewer-image-and-navbar .viewer-navbar-label {
+      display: inline;
+    }
+  }
+}

--- a/app/assets/stylesheets/local/show.scss
+++ b/app/assets/stylesheets/local/show.scss
@@ -24,11 +24,13 @@
   }
 
   // main one should have btn-primary colors.
-  .work-show-representative .show-page-image .show-page-image-bar {
+  .work-show-representative .show-page-image .show-page-image-bar .btn-primary:not(:hover):not(:active):not(:focus) {
     background: transparentize($btn-primary-bg, .3);
-    .btn-primary {
-      border-color: darken($btn-primary-border, .3);
-    }
+    border-color: darken($btn-primary-border, .3);
+  }
+  // and be big big
+  .work-show-representative .show-page-image .show-page-image-bar .btn {
+    font-size: 125%;
   }
 
   header h1 {
@@ -99,20 +101,13 @@
   // elements are absolutely positioned within it.
   .show-page-image {
     position: relative;
+    cursor: pointer;
 
     .show-page-image-image {
       width: 100%;
       // keep crazy long aspect ratio images from being
       // so long, although there will be some distortion.
       max-height: 80vw;
-    }
-
-    // An <a> that's over the whole image to make sure it's clickable
-    .show-page-image-viewer-link {
-      display: block;
-      position: absolute;
-      width: 100%;
-      height: 100%;
     }
 
     .show-page-member-title {
@@ -146,10 +141,7 @@
       bottom: 0;
       left: 0;
       right: 0;
-      background: transparentize($brand-inverse, .3);
-      .btn-primary {
-        border-color: darken($brand-inverse, 5%);
-      }
+
       .btn-group {
         width: 100%;
         .btn { width: 100%; }
@@ -157,17 +149,13 @@
           left: 5px;
         }
       }
-      a, button {
+      & > button, & > .btn, & > .btn-group > button {
         flex: 1;
         border-radius: 0;
-        background: transparent;
       }
-    }
-
-    &:hover .show-page-image-bar {
-      background: transparentize($btn-primary-bg, .3);
-      .btn-primary {
-        border-color: darken($btn-primary-border, .3);
+      .btn-primary:not(:hover):not(:active):not(:focus) {
+        background: transparentize($brand-inverse, .3);
+        border-color: darken($brand-inverse, 5%);
       }
     }
 

--- a/app/presenters/curation_concerns/generic_work_show_presenter.rb
+++ b/app/presenters/curation_concerns/generic_work_show_presenter.rb
@@ -56,6 +56,17 @@ module CurationConcerns
       solr_document.visibility != Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
     end
 
+    # override to cache, cause it's expensive and we need it twice to display
+    # our viewer with thumbs, at present.
+    # See https://github.com/samvera-labs/hyrax/pull/1160
+    def member_presenters(*args)
+      # cache based on args, gah. We really don't understand what's going on,
+      # but we need to do something with this super-expensive call to make it less so,
+      # to support our custom show/viewer.
+      @_member_presenters ||= {}
+      @_member_presenters[args] ||= super
+    end
+
     # Member presenters, but if our representative image is the FIRST image,
     # don't bother repeating it below.
     def show_thumb_member_presenters

--- a/app/views/curation_concerns/base/_chf_image_viewer.html.erb
+++ b/app/views/curation_concerns/base/_chf_image_viewer.html.erb
@@ -1,0 +1,63 @@
+<%# The image viewer, contained in a partial. Might later change this to
+    some kind of JS templates or other fancy JS, instead of just server-side
+    HTML all pre-rendered invisible on page like it is now.
+
+    local args:
+      * work
+ %>
+<div id="chf-image-viewer-modal" class="modal" tabindex="-1" role="dialog">
+  <div class="modal-dialog" role="document">
+    <div class="modal-content">
+      <div class="modal-body">
+        <div id= "chf-image-viewer" class="chf-image-viewer">
+          <div class="viewer-header">
+
+            <%= link_to main_app.root_path do %>
+              <%= image_tag "chf_logo_white.svg", class: "chf-logo" %>
+            <% end %>
+
+            <h1>
+              <a data-trigger="chf_image_viewer_close" href="#"><%= work.title.first %></a>
+            </h1>
+
+            <a href="#" data-trigger="chf_image_viewer_close" class="header-close">
+              <i class="fa fa-times"></i>
+            </a>
+          </div>
+
+          <div class="viewer-content">
+
+            <div class="viewer-image-and-navbar">
+              <div class="viewer-image" id="openseadragon-container">
+                <button href="#" id="viewer-left" class="viewer-image-prev" data-trigger="viewer-prev" tabindex="0"><i class="fa fa-chevron-left" title="Previous"></i></button>
+                <button href="#" id="viewer-right" class="viewer-image-next" data-trigger="viewer-next" tabindex="0"><i class="fa fa-chevron-right" title="Next"></i></button>
+              </div>
+
+              <%= render "chf_image_viewer_navbar", count: work.member_presenters.count %>
+            </div>
+
+            <%= content_tag "div", id:"viewer-thumbs", class: "viewer-thumbs", data: { total_count: work.member_presenters.count } do %>
+              <% work.member_presenters.each_with_index do |member_presenter, i| -%>
+                <%= tag "img",
+                    class: "lazyload viewer-thumb-img",
+                    alt: "",
+                    tabindex: "0",
+                    role: "button",
+                    data: {
+                      trigger: 'change-viewer-source',
+                      index: i + 1,
+                      title: member_presenter.link_name,
+                      member_should_show_info: member_presenter.model_name.to_s != "FileSet",
+                      member_id: member_presenter.representative_id,
+                      member_show_url: contextual_path(member_presenter, work),
+                      src: member_presenter.first(blacklight_config.view_config(document_index_view_type).thumbnail_field)
+                    }
+                -%>
+              <%- end -%>
+            <% end %>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/curation_concerns/base/_chf_image_viewer_navbar.html.erb
+++ b/app/views/curation_concerns/base/_chf_image_viewer_navbar.html.erb
@@ -1,0 +1,91 @@
+<%# the button navbar at the bottom of the image viewer. Shouldn't really be used
+    outside the image viewer, but extracted for clarity.
+
+    Needs locals:
+      * `count`
+
+    Many of the content areas in here are actually filled in by the viewer JS
+%>
+
+<div class="viewer-navbar btn-group" role="group" aria-label="actions">
+    <div id="viewer-pagination" class="viewer-pagination viewer-navbar-btn">
+      <span class="viewer-pagination-numerator"></span> / <%= count %>
+    </div>
+
+    <div id="viewer-spacer" class="viewer-spacer"></div>
+
+    <a id="viewer-member-info" class="viewer-navbar-btn viewer-member-info" tabindex="0" data-hook="viewer-navbar-info-link">
+      <i class="fa fa-external-link"></i>
+      <span data-hook="viewer-navbar-title-label"></span>
+    </a>
+
+    <div class="viewer-navbar-btn btn-group dropup viewer-download" role="group">
+      <button id="btnGroupDrop1" type="button" class="btn btn-lg btn-primary dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" tabindex="0">
+        <i class="fa fa-download"></i> <span class="viewer-navbar-label">Download</span>
+      </button>
+      <ul class="dropdown-menu" aria-labelledby="btnGroupDrop1">
+        <li><a href="#">Sorry, not yet implemented</a></li>
+      </ul>
+    </div>
+
+    <button class="viewer-navbar-btn btn btn-lg btn-primary viewer-fullscreen viewer-thin-btn" id="viewer-fullscreen" data-trigger="viewer-fullscreen" tabindex="0" title="Fullscreen">
+      <i class="fa fa-arrows-alt"></i>
+    </button>
+
+    <a class="viewer-navbar-btn btn btn-lg btn-primary viewer-rotate-right viewer-thin-btn" id="viewer-rotate-right" tabindex="0">
+      <i class="fa fa-repeat"></i>
+    </a>
+
+    <a class="viewer-navbar-btn btn btn-lg btn-primary viewer-zoom-fit viewer-thin-btn" id="viewer-zoom-fit" tabindex="0">
+      <i class="fa fa-home"></i>
+    </a>
+    <a class="viewer-navbar-btn btn btn-lg btn-primary viewer-zoom-in viewer-thin-btn" id="viewer-zoom-in" tabindex="0">
+      <i class="fa fa-search-plus"></i>
+    </a>
+    <a class="viewer-navbar-btn btn btn-lg btn-primary viewer-zoom-out viewer-thin-btn" id="viewer-zoom-out" tabindex="0">
+      <i class="fa fa-search-minus"></i>
+    </a>
+
+    <div class="viewer-navbar-btn btn-group dropup viewer-keyboard viewer-thin-btn" role="group">
+      <%# this isn't really a dropdown menu, but that bootstrap works best as
+          a starting point for a popup info area, it turns out. popover doesn't
+          behave how we want. %>
+      <button id="btnViewerKeyboard" type="button" class="viewer-navbar-btn btn btn-lg btn-primary dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" tabindex="0">
+        <i class="fa fa-keyboard-o"></i>
+      </button>
+      <ul class="dropdown-menu" aria-labelledby="btnViewerKeyboard">
+        <li>
+          <h3>Keyboard Shortcuts</h3>
+          <table class="table">
+            <tr>
+              <td>Previous image</td><td><kbd>shift + <i class="fa fa-arrow-left"></i></kbd> or <kbd>,</kbd></td>
+            </tr>
+            <tr>
+              <td>Next image</td><td><kbd>shift + <i class="fa fa-arrow-right"></i></kbd> or <kbd>.</kbd></td>
+            </tr>
+            <tr>
+              <td>Pan image</td><td><kbd><i class="fa fa-arrow-left"></i></kbd> <kbd><i class="fa fa-arrow-right"></i></kbd> <kbd><i class="fa fa-arrow-up"></i></kbd> <kbd><i class="fa fa-arrow-down"></i></kbd></td>
+            </tr>
+            <tr>
+              <td>Zoom in</td><td><kbd>+</kbd> or <kbd>shift + <i class="fa fa-arrow-up"></i></kbd></td>
+            </tr>
+            <tr>
+              <td>Zoom out</td><td><kbd>-</kbd> or <kbd>shift + <i class="fa fa-arrow-down"></i></kbd></td>
+            </tr>
+            <tr>
+              <td>Zoom to fit</td><td><kbd>0</kbd></td>
+            </tr>
+            <tr>
+              <td>Close viewer</td><td><kbd>esc</kbd></td>
+            </tr>
+            <tr>
+              <td colspan=2>
+                <b><i>Also</i></b><br>
+                Mouse click to zoom in; shift-click to zoom out. Drag to pan. Pinch to zoom on touch.
+              </td>
+            </tr>
+          </table>
+        </li>
+      </ul>
+    </div>
+</div>

--- a/app/views/curation_concerns/base/_show_page_image.html.erb
+++ b/app/views/curation_concerns/base/_show_page_image.html.erb
@@ -1,8 +1,13 @@
 <%# CHF custom, an image with overlaid controls and info. Used as an alternative to
     `representative_media` for show page, as well as for page thumbs on show page %>
-<%= content_tag("div", class: ["show-page-image"] + Array(local_assigns[:extra_classes])) do %>
-  <a href="javascript: alert('this would open a viewer but not implemented yet');" class="show-page-image-viewer-link"></a>
-
+<%= content_tag("div",
+      tabindex: "0",
+      data: {
+        trigger: "chf_image_viewer",
+        member_id: member.representative_id
+      },
+      class: ["show-page-image"] + Array(local_assigns[:extra_classes])) do
+%>
     <% if local_assigns[:lazy_after] && member_counter > local_assigns[:lazy_after] - 1 %>
       <%= image_tag nil,
                     class: "lazyload show-page-image-image",
@@ -14,7 +19,11 @@
     <% else %>
       <%= image_tag main_app.download_path(member.representative_id, file: "jpeg"),
                     class: "show-page-image-image",
-                    alt: ""
+                    alt: "",
+                    data: {
+                      trigger: "chf_image_viewer",
+                      member_id: member.id
+                    }
       %>
     <% end %>
 
@@ -46,7 +55,14 @@
               <%= link_to main_app.download_path(member.representative_id),
                           target: "_new",
                           id: "file_download",
-                          data: { label: member.id } do %>
+                          data: {
+                            label: member.id,
+                            # These action/labels are what sufia/hyrax uses, although
+                            # a bit weird. https://github.com/samvera/hyrax/blob/1e504c200fd9c39120f514ac33cd42cd843de9fa/app/assets/javascripts/hyrax/ga_events.js
+                            analytics_event: "Files",
+                            analytics_label: "Downloaded",
+                            analytics_value: member.representative_id
+                          } do %>
                   Original Image
               <% end %>
             </li>

--- a/app/views/curation_concerns/base/show.html.erb
+++ b/app/views/curation_concerns/base/show.html.erb
@@ -60,4 +60,5 @@
   %>
 </div>
 
+<%= render 'chf_image_viewer', work: @presenter  %>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -42,6 +42,13 @@ Rails.application.routes.draw do
   curation_concerns_embargo_management
   concern :exportable, Blacklight::Routes::Exportable.new
 
+  # there might be a way to get curation_concerns routes to this for us,
+  # but don't know it, and this is easy enough and works. Make the viewer
+  # URL lead to ordinary show page, so JS can pick it up and launch viewer.
+  get '/concern/generic_works/:id/viewer/:filesetid(.:format)' => 'curation_concerns/generic_works#show'
+  get '/concern/parent/:parent_id/generic_works/:id/viewer/:filesetid(.:format)' => 'curation_concerns/generic_works#show'
+
+
   resources :solr_documents, only: [:show], path: '/catalog', controller: 'catalog' do
     concerns :exportable
   end


### PR DESCRIPTION
This is pulled on top of work_show_page branch. 

It's not _quite_ done, but close. 

UI to note:

* Still no high-res images, so you can't actually zoom in very far. 
* tab-to-link nav works on show page and viewer. (mostly, I think). This was surprisingly challenging, but worth it!
* Try out the "full screen" button especially on a large desktop display. How's that for interacting with a text?!?
* Keyboard shortcuts, click the keyboard button to see em
* Yes, I'm not totally happy with the bottom nav bar either, but haven't come up with something better, and I feel like running out of budgetted time on this, have to move on to something else, probably good enough for now. 
* There is a bug in header/footer layout on show page I still need to figure out. 

I am most interested in if you can find any _bugs_, things that don't work right, rather than feedback on colors/spacing/layout/etc.  The bugs are higher priority of course!

Technical things I need to look into:

- [x] Google analytics
- [x] Fix on IE11. (Postponing IE10 for now, decided it's okay it doesn't)
- [ ] Non public members should not show up for the public. See #575
- [x] bug where next doc right after opening the viewer doesn't update url
- [x] reorganize class and id names to be consistent, all start with `viewer-`. 
- [x] Escape on an open popup menu should close the menu not the viewer
- [x] There is a bug in header/footer layout on show page I still need to figure out. 
- [x] next/prev buttons not vertically centered on FF
- [x] need a loading spinner on page image change, especially once we're using slower riiif
- [x] next/prev scroll to thumb should be more gentle
- [x] remember focused image on show page keep it focused when you close viewer (better for keyboard nav)
- [x] for a child work with a long title, it pushes the rest of the viewer buttons off screen for me
for ex: https://staging.digital.chemheritage.org/concern/generic_works/h128nd97r/viewer/8c97kq68v
- [x] for the same work as above, when i click on the 2nd or 3rd (or any) child work, it always brings up the representative work instead, this doesn't happen for a work with only files
- [x] thumbs wrapping at one thumb instead of two in hard to repro way