### PR TITLE
Better fixity failure notification messages

### DIFF
--- a/app/services/chf/fixity_check_failure_service.rb
+++ b/app/services/chf/fixity_check_failure_service.rb
@@ -27,23 +27,29 @@ module CHF
 
     def message
       <<-EOF
-<p>hostname: #{`hostname`.chomp}</p>
+<p>hostname: #{`hostname`.chomp}
+</p>
 
 <p>Fixity check failure at #{log_created_at}<br>
-  for: <a href="#{checked_uri}/fcr:metadata">#{checked_uri}/fcr:metadata</a></p>
+  for: #{checked_uri_fedora_metadata_uri}
+</p>
 
-<p>Expected fixity result: #{expected_result}</p>
+<p>Expected fixity result: #{expected_result}
+</p>
 
 <p>work:
-  #{works_message}</p>
+  #{works_message}
+</p>
 
 
-<p>file_set: #{file_set_id} #{file_set_title}
-  <a href="#{file_set_app_path}">#{file_set_app_path}</a>
-  <a href="#{file_set.try(:uri)}/fcr:metadata">#{file_set.try(:uri)}/fcr:metadata</a></p>
+<p>file_set: #{file_set_id} #{file_set_title}<br>
+  <a href="#{file_set_app_path}">#{file_set_app_path}</a><br>
+  #{file_set_fedora_metadata_uri}
+</p>
 
-<p>file: #{file_id}
-  <a href="#{file_fedora_metadata_uri}">#{file_fedora_metadata_uri}</a></p>
+<p>file: #{file_id}<br>
+  #{file_fedora_metadata_uri}
+</p>
 
 <p>Logged in ChecksumAuditLog: #{ERB::Util.html_escape checksum_audit_log.inspect}</p>
   EOF
@@ -69,9 +75,21 @@ module CHF
       end.join("\n")
     end
 
+    # with actual hostname (prob internal IP) replaced with `FEDORA`
     def file_fedora_metadata_uri
       file_uri = Hydra::PCDM::File.translate_id_to_uri.call(file_id)
-      file_uri && "#{file_uri}/fcr:metadata"
+      file_uri && prepare_display_uri("#{file_uri}/fcr:metadata")
+    end
+
+    # with actual hostname (prob internal IP) replaced with `FEDORA`
+    def file_set_fedora_metadata_uri
+      if file_set
+        prepare_display_uri("#{file_set.uri}/fcr:metadata")
+      end
+    end
+
+    def checked_uri_fedora_metadata_uri
+      prepare_display_uri("#{checked_uri}/fcr:metadata")
     end
 
     def log_created_at
@@ -96,6 +114,14 @@ module CHF
 
     def expected_result
       checksum_audit_log.try(:expected_result)
+    end
+
+    # replace real hostname with 'FEDORA', cause real hostname is probably
+    # an AWS internal-only IP address, and we don't have access to the actual
+    # external hostname/IP at present.  Replace fcr:verisons with escaped
+    # version because of bug in fedora. https://jira.duraspace.org/browse/FCREPO-1247
+    def prepare_display_uri(uri)
+      uri.to_s.sub(%r{//[^/]+(:\d{1,4})/}, '//FEDORA\1/').sub(/fcr:versions/, "fcr%3aversions")
     end
   end
 end

--- a/app/services/chf/fixity_check_failure_service.rb
+++ b/app/services/chf/fixity_check_failure_service.rb
@@ -50,7 +50,7 @@ module CHF
     end
 
     def subject
-      "FIXITY CHECK FAILURE: #{file_set_title}"
+      "FIXITY CHECK FAILURE: #{Socket.gethostname}: #{file_set_title}"
     end
 
     protected

--- a/spec/services/hyrax/file_set_fixity_check_service_spec.rb
+++ b/spec/services/hyrax/file_set_fixity_check_service_spec.rb
@@ -39,10 +39,11 @@ describe Hyrax::FileSetFixityCheckService do
 
       expect(last_email.to).to eq(["digital-tech@chemheritage.org"])
       expect(last_email.from).to eq(["digital-tech@chemheritage.org"])
-      expect(last_email.subject).to eq("FIXITY CHECK FAILURE: sample.jpg")
+      expect(last_email.subject).to match(/\AFIXITY CHECK FAILURE: #{Regexp.escape(Socket.gethostname)}: sample\.jpg\Z/)
+
       expect(last_email.body.to_s).to include(file_set.id)
       expect(last_email.body.to_s).to include(file_id)
-      expect(last_email.body.to_s).to include(checked_uri)
+      expect(last_email.body.to_s).to include(URI.parse(checked_uri).path.sub("fcr:versions", "fcr%3aversions"))
       expect(last_email.body.to_s).to include(expected_message_digest)
       expect(last_email.body.to_s).to include(log.created_at.in_time_zone.to_s)
       expect(last_email.body.to_s).to include("ChecksumAuditLog id: #{log.id}")


### PR DESCRIPTION
* add Socket.gethostname to fixity check failure subjects
* Don't include internal only IPs. No hostnames at all for now, oh well.
* Do include the fedora bug workaround escaping the colons in fcr:versions