### PR TITLE
keep collection show image from overflowing it's place

### DIFF
--- a/app/assets/stylesheets/local/collections.scss
+++ b/app/assets/stylesheets/local/collections.scss
@@ -50,3 +50,9 @@ $collection-index-box-margin: 17px;
     }
   }
 }
+
+.collection-show-media {
+  img {
+    max-width: 100%;
+  }
+}


### PR DESCRIPTION
until we get to redesigning this page entirely, keep it working.

before change:

![screen shot 2017-06-20 at 5 11 34 pm](https://user-images.githubusercontent.com/149304/27356292-f2697974-55db-11e7-9955-63fb9809cafe.png)
