### PR TITLE
riiif-provided srcset images on show page

### DIFF
--- a/app/assets/stylesheets/local/show.scss
+++ b/app/assets/stylesheets/local/show.scss
@@ -93,7 +93,7 @@
       width: 100%;
       // keep crazy long aspect ratio images from being
       // so long, although there will be some distortion.
-      max-height: 80vw;
+      max-height: 80vh;
     }
 
     .show-page-member-title {

--- a/app/helpers/curation_concerns_helper.rb
+++ b/app/helpers/curation_concerns_helper.rb
@@ -6,7 +6,7 @@ module CurationConcernsHelper
   # do what CC/Sufia did before.
   def show_page_representative_media(presenter)
     if presenter.representative_id.present? && presenter.representative_presenter.present? && presenter.representative_presenter.image?
-      render 'show_page_image', member: presenter.representative_presenter
+      render 'show_page_image', member: presenter.representative_presenter, size: :large
     else
       render 'representative_media', presenter: presenter
     end

--- a/app/helpers/riiif_helper.rb
+++ b/app/helpers/riiif_helper.rb
@@ -30,4 +30,14 @@ module RiiifHelper
     end
   end
 
+  # On show page, we just use pixel density source set, passing in the LARGEST width needed for
+  # any responsiveness page layout. Sends somewhat more bytes when needed at some responsive
+  # sizes, but way simpler to implement; keep from asking riiiif for even more varying resizes;
+  # prob good enough.
+  def riiif_image_srcset_pixel_density(riiif_file_id, base_width, format: 'jpg', quality: 'default')
+    [1, BigDecimal.new('1.5'), 2, 3, 4].collect do |multiplier|
+      riiif_image_url(riiif_file_id, format: "jpg", size: "#{base_width * multiplier},") + " #{multiplier}x"
+    end.join(", ")
+  end
+
 end

--- a/app/views/curation_concerns/base/_show_page_image.html.erb
+++ b/app/views/curation_concerns/base/_show_page_image.html.erb
@@ -1,5 +1,20 @@
 <%# CHF custom, an image with overlaid controls and info. Used as an alternative to
-    `representative_media` for show page, as well as for page thumbs on show page %>
+    `representative_media` for show page, as well as for page thumbs on show page
+
+    Locals:
+      * size: :large (used for big hero image) or :medium used for subsequent
+        page images. Default :medium
+      * lazy_after: optional. used when this is used as a collection partial, make images
+          lazy loading after the first N images, where N is the lazy_after value.
+      * extra_classes: optional. extra CSS calsses added to the wrapper <div> tag.
+
+%>
+<%
+   # this was just derived from just looking in the browser at our present
+   # CSS, what's the widest the 'large' and 'medium' images can be at
+   # any responsive CSS?
+   base_width = local_assigns[:size] == :large ? 525 : 208
+%>
 <%= content_tag("div",
       tabindex: "0",
       data: {
@@ -13,12 +28,14 @@
                     class: "lazyload show-page-image-image",
                     alt: "",
                     data: {
-                      src: main_app.download_path(member.representative_id, file: "jpeg")
+                      src: riiif_image_url(member.riiif_file_id, format: "jpg", size: "#{base_width},"),
+                      srcset: riiif_image_srcset_pixel_density(member.riiif_file_id, base_width)
                     }
       %>
     <% else %>
-      <%= image_tag main_app.download_path(member.representative_id, file: "jpeg"),
+      <%= image_tag riiif_image_url(member.riiif_file_id, format: "jpg", size: "#{base_width},"),
                     class: "show-page-image-image",
+                    srcset: riiif_image_srcset_pixel_density(member.riiif_file_id, base_width),
                     alt: "",
                     data: {
                       trigger: "chf_image_viewer",


### PR DESCRIPTION
Closes #636. 

Just did show page, not viewer. On viewer, using the derivative 'thumb' (which I think we need anyway), is about 2x "retina" size already, and relatively small files already, good enough for now I think. 