### PR TITLE
A CHF::Env class that we will access infrastructure/environmental config from.

### DIFF
--- a/app/helpers/riiif_helper.rb
+++ b/app/helpers/riiif_helper.rb
@@ -5,8 +5,8 @@ module RiiifHelper
   # Returns relative url unless we've defind a riiif server in config/environments/*.rb
   def riiif_info_url (riiif_file_id)
     path = riiif.info_path(riiif_file_id, locale: nil)
-    if Rails.configuration.respond_to? :riiif_server
-      return URI.join(Rails.configuration.riiif_server, path).to_s
+    if CHF::Env.lookup(:public_riiif_url)
+      return URI.join(CHF::Env.lookup(:public_riiif_url), path).to_s
     else
       return path
     end
@@ -23,8 +23,8 @@ module RiiifHelper
   def riiif_image_url(riiif_file_id, format: 'jpg', size: "full", quality: 'default')
     path = riiif.image_path(riiif_file_id, locale: nil, size: size, format: format, quality: quality)
 
-    if Rails.configuration.respond_to? :riiif_server
-      return URI.join(Rails.configuration.riiif_server, path).to_s
+    if CHF::Env.lookup(:public_riiif_url)
+      return URI.join(CHF::Env.lookup(:public_riiif_url), path).to_s
     else
       return path
     end

--- a/app/models/chf/env.rb
+++ b/app/models/chf/env.rb
@@ -1,0 +1,123 @@
+module CHF
+  # A central place for environmental/infrastructure type configuration.
+  # We still have lots of this in other places too that predates this, but
+  # this is our attempt to centralize it.
+  #
+  # Values will be taken from, in priority order:
+  #   * ENV if present -- uppercased. ENV['FOO_BAR'] for key 'foo_bar'. Or can set custom ENV key per config key.
+  #   * else the config/local_env.yml file if present and has key. This file
+  #     is supplied by ansible with level/role-specific values, or might
+  #     be created by hand in dev if convenient.
+  #   * defaults configured in this class.
+  #
+  # Lookup with:
+  #
+  #     Chf::Env.lookup("some_key")
+  #
+  # You can only look up keys defined like so:
+  #
+  #     define_key(:some_key)
+  #     define_key(:some_key, env: false) # disable ENV lookup
+  #     define_key(:some_key, env: "SPECIFY_ENV_VAR") # non-defualt ENV lookup key
+  #     define_key(:some_key, default: "foo")
+  #     define_key(:some_key, default: -> { proc_that_provides_value} ) # will only be called once and cached
+  #
+  # Keys are defined at the bottom of this file, to make sure all methods are
+  # defined first! (Extract to another file? Want to make sure they get defined
+  # right away so can be used at any point in boot process)
+  #
+  # This implementation is a bit hacky, but I think the public API is hopefully
+  # good and stable.
+  class Env
+
+
+    def initialize
+      @key_definitions = {}
+      @local_env_path = Rails.root.join('config', 'local_env.yml')
+    end
+
+    def self.define_key(*args)
+      instance.define_key(*args)
+    end
+
+    def self.lookup(*args)
+      instance.lookup(*args)
+    end
+
+    def define_key(name, env_key: nil, default: nil)
+      @key_definitions[name.to_sym] = {
+        name: name.to_s,
+        env_key: env_key,
+        default: default
+      }
+    end
+
+    def lookup(name)
+      defn = @key_definitions[name.to_sym]
+      raise ArgumentError.new("No env key defined for: #{name}") unless defn
+
+      system_env_lookup(defn) || local_env_file_lookup(defn) || default_lookup(defn)
+    end
+
+    protected
+
+    def system_env_lookup(defn)
+      return nil if defn[:env_key] == false
+
+      ENV[defn[:env_key] || defn[:name].upcase]
+    end
+
+    def local_env_file_lookup(defn)
+      @local_env_loaded ||= load_yaml_file
+      @local_env_loaded[defn[:name]]
+    end
+
+    def load_yaml_file
+      return {} unless File.exist?(@local_env_path)
+      YAML.load(File.open(@local_env_path))
+    end
+
+    # default lookup is cached, this kind of env config should be immutable
+    def default_lookup(defn)
+      if defn.has_key?(:cached_default)
+        defn[:cached_default]
+      else
+        defn[:cached_default] = if defn[:default].respond_to?(:call)
+                                  # allow a proc that gets executed on demand
+                                  defn[:default].call
+                                else
+                                  defn[:default]
+                                end
+      end
+    end
+
+    public
+
+    @instance = self.new
+    def self.instance
+      @instance
+    end
+
+    ######
+    #
+    #  Define keys here
+    #
+    ######
+
+    self.define_key :public_riiif_url
+    self.define_key :app_role
+    self.define_key :service_level
+
+    # Ideally these would be in local_env.yml independently,
+    # but for now we calculate based on app_role value, but do it here
+    # so we have one place to change.
+    # Can still override with ENV or local_env.yml locally, nice!
+    self.define_key :serve_riiif_paths, default: -> {
+      lookup(:app_role).blank? || lookup(:app_role) == "riiif"
+    }
+    self.define_key :serve_app_paths, default: -> {
+      lookup(:app_role).blank? || lookup(:app_role) == "app"
+    }
+
+  end
+end

--- a/app/models/chf/env.rb
+++ b/app/models/chf/env.rb
@@ -108,6 +108,12 @@ module CHF
     define_key :app_role
     define_key :service_level
 
+    define_key :riiif_originals_cache, default: -> {
+      Rails.env.production? ? "/var/sufia/riiif-originals" : Rails.root.join("tmp", "riiif-originals").to_s
+    }
+    define_key :riiif_derivatives_cache, default: -> {
+      Rails.env.production? ? "/var/sufia/riiif-derivatives" : Rails.root.join("tmp", "riiif-derivatives").to_s
+    }
 
 
     # Ideally these would be in local_env.yml independently,

--- a/app/models/chf/env.rb
+++ b/app/models/chf/env.rb
@@ -104,18 +104,20 @@ module CHF
     #
     ######
 
-    self.define_key :public_riiif_url
-    self.define_key :app_role
-    self.define_key :service_level
+    define_key :public_riiif_url
+    define_key :app_role
+    define_key :service_level
+
+
 
     # Ideally these would be in local_env.yml independently,
     # but for now we calculate based on app_role value, but do it here
     # so we have one place to change.
     # Can still override with ENV or local_env.yml locally, nice!
-    self.define_key :serve_riiif_paths, default: -> {
+    define_key :serve_riiif_paths, default: -> {
       lookup(:app_role).blank? || lookup(:app_role) == "riiif"
     }
-    self.define_key :serve_app_paths, default: -> {
+    define_key :serve_app_paths, default: -> {
       lookup(:app_role).blank? || lookup(:app_role) == "app"
     }
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -9,13 +9,6 @@ Bundler.require(*Rails.groups)
 module Chufia
   class Application < Rails::Application
 
-    config.before_configuration do
-      env_file = File.join(Rails.root, 'config', 'local_env.yml')
-      YAML.load(File.open(env_file)).each do |key, value|
-        ENV[key.to_s] = value
-      end if File.exists?(env_file)
-    end
-
     # The compile method (default in tinymce-rails 4.5.2) doesn't work when also
     # using tinymce-rails-imageupload, so revert to the :copy method
     # https://github.com/spohlenz/tinymce-rails/issues/183

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,7 +1,4 @@
 Rails.application.configure do
-  # configure a remote riiif box to point users to
-  config.riiif_server = ENV['public_riiif_url']
-
   # Settings specified here will take precedence over those in config/application.rb.
   config.action_mailer.default_url_options = { :host => 'digital.chemheritage.org' }
   config.action_mailer.delivery_method = :sendmail

--- a/config/initializers/riiif.rb
+++ b/config/initializers/riiif.rb
@@ -1,6 +1,9 @@
 # Get files via HTTP (they're in fedora)
 Riiif::Image.file_resolver = Riiif::HTTPFileResolver.new
 
+Riiif::Image.file_resolver.cache_path = CHF::Env.lookup(:riiif_originals_cache)
+Riiif::Image.cache = ActiveSupport::Cache::FileStore.new(CHF::Env.lookup(:riiif_derivatives_cache))
+
 # Tell RIIIF how to resolve the identifier to a URI in Fedora
 Riiif::Image.file_resolver.id_to_uri = lambda do |id|
   ActiveFedora::Base.id_to_uri(CGI.unescape(id)).tap do |url|

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,76 +1,85 @@
 require 'resque/server'
 
 Rails.application.routes.draw do
-  # override sufia's about routing to use a static page instead of a content block
-  get 'about', controller: 'static', action: 'about', as: 'about'
+  # RIIIF server should serve ONLY riiif paths; app server anything BUT riiif paths
+  # development server (or any other server you configure cause you want it) can still serve both
 
-  concern :range_searchable, BlacklightRangeLimit::Routes::RangeSearchable.new
-  Hydra::BatchEdit.add_routes(self)
-  mount Qa::Engine => '/authorities'
-  mount Riiif::Engine => '/image-service', as: 'riiif'
+  constraints ->(request) { CHF::Env.lookup(:serve_riiif_paths) } do
+    mount Riiif::Engine => '/image-service', as: 'riiif'
+  end
 
-  # Administrative URLs
-  namespace :admin do
-    # Job monitoring
-    constraints ResqueAdmin do
-      mount Resque::Server, at: 'queues'
+
+  constraints ->(request) { CHF::Env.lookup(:serve_app_paths) } do
+    # override sufia's about routing to use a static page instead of a content block
+    get 'about', controller: 'static', action: 'about', as: 'about'
+
+    concern :range_searchable, BlacklightRangeLimit::Routes::RangeSearchable.new
+    Hydra::BatchEdit.add_routes(self)
+    mount Qa::Engine => '/authorities'
+
+    # Administrative URLs
+    namespace :admin do
+      # Job monitoring
+      constraints ResqueAdmin do
+        mount Resque::Server, at: 'queues'
+      end
     end
-  end
 
-  mount Blacklight::Engine => '/'
+    mount Blacklight::Engine => '/'
 
-    concern :searchable, Blacklight::Routes::Searchable.new
+      concern :searchable, Blacklight::Routes::Searchable.new
 
-  resource :catalog, only: [:index], as: 'catalog', path: '/catalog', controller: 'catalog' do
-    concerns :searchable
-    concerns :range_searchable
+    resource :catalog, only: [:index], as: 'catalog', path: '/catalog', controller: 'catalog' do
+      concerns :searchable
+      concerns :range_searchable
 
-  end
-
-  devise_for :users
-  # https://github.com/plataformatec/devise/wiki/how-to:-change-the-default-sign_in-and-sign_out-routes
-  devise_scope :user do
-    get 'login', to: 'devise/sessions#new'
-  end
-
-  # make the contact form inaccessible since we're using mailto
-  get 'contact', to: redirect('/404')
-
-  resources :welcome, only: 'index'
-  root 'sufia/homepage#index'
-  curation_concerns_collections
-  curation_concerns_basic_routes
-  curation_concerns_embargo_management
-  concern :exportable, Blacklight::Routes::Exportable.new
-
-  # there might be a way to get curation_concerns routes to this for us,
-  # but don't know it, and this is easy enough and works. Make the viewer
-  # URL lead to ordinary show page, so JS can pick it up and launch viewer.
-  get '/concern/generic_works/:id/viewer/:filesetid(.:format)' => 'curation_concerns/generic_works#show'
-  get '/concern/parent/:parent_id/generic_works/:id/viewer/:filesetid(.:format)' => 'curation_concerns/generic_works#show'
-
-
-  resources :solr_documents, only: [:show], path: '/catalog', controller: 'catalog' do
-    concerns :exportable
-  end
-
-  resources :bookmarks do
-    concerns :exportable
-
-    collection do
-      delete 'clear'
     end
+
+    devise_for :users
+    # https://github.com/plataformatec/devise/wiki/how-to:-change-the-default-sign_in-and-sign_out-routes
+    devise_scope :user do
+      get 'login', to: 'devise/sessions#new'
+    end
+
+    # make the contact form inaccessible since we're using mailto
+    get 'contact', to: redirect('/404')
+
+    resources :welcome, only: 'index'
+    root 'sufia/homepage#index'
+    curation_concerns_collections
+    curation_concerns_basic_routes
+    curation_concerns_embargo_management
+    concern :exportable, Blacklight::Routes::Exportable.new
+
+    # there might be a way to get curation_concerns routes to this for us,
+    # but don't know it, and this is easy enough and works. Make the viewer
+    # URL lead to ordinary show page, so JS can pick it up and launch viewer.
+    get '/concern/generic_works/:id/viewer/:filesetid(.:format)' => 'curation_concerns/generic_works#show'
+    get '/concern/parent/:parent_id/generic_works/:id/viewer/:filesetid(.:format)' => 'curation_concerns/generic_works#show'
+
+
+    resources :solr_documents, only: [:show], path: '/catalog', controller: 'catalog' do
+      concerns :exportable
+    end
+
+    resources :bookmarks do
+      concerns :exportable
+
+      collection do
+        delete 'clear'
+      end
+    end
+
+    # local routes
+    get '/opac_data/:rec_num', to: 'opac_data#load_bib'
+    mount Hydra::RoleManagement::Engine => '/'
+
+    get '/focus/:id', to: 'synthetic_category#show', as: :synthetic_category
+
+
+    Hydra::BatchEdit.add_routes(self)
+    # Sufia should be mounted before curation concerns to give priority to its routes
+    mount Sufia::Engine => '/'
+    mount CurationConcerns::Engine, at: '/'
   end
-
-  # local routes
-  get '/opac_data/:rec_num', to: 'opac_data#load_bib'
-  mount Hydra::RoleManagement::Engine => '/'
-
-  get '/focus/:id', to: 'synthetic_category#show', as: :synthetic_category
-
-
-  Hydra::BatchEdit.add_routes(self)
-  # Sufia should be mounted before curation concerns to give priority to its routes
-  mount Sufia::Engine => '/'
-  mount CurationConcerns::Engine, at: '/'
 end

--- a/lib/tasks/chf_tasks.rake
+++ b/lib/tasks/chf_tasks.rake
@@ -201,7 +201,6 @@ namespace :chf do
   end
 
   namespace :user do
-
     desc 'Create a user without a password; they can request one from the UI'
     task :create, [:email] => :environment do |t, args|
       u = User.create!(email: args[:email])
@@ -215,7 +214,19 @@ namespace :chf do
         u = User.create!(email: args[:email], password: args[:pass])
         puts "Test user created"
       end
-
     end
   end
+
+  namespace :riiif do
+    desc "Delete all files in both riiif caches"
+    task :clear_caches do
+      # We're not doing an :environment rake dep for speed so need to load
+      # our CHF::Env.
+      require Rails.root.join("app", "models", "chf", "env").to_s
+      Pathname.new(CHF::Env.lookup(:riiif_originals_cache)).children.each { |p| p.rmtree }
+      Pathname.new(CHF::Env.lookup(:riiif_derivatives_cache)).children.each { |p| p.rmtree }
+    end
+  end
+
+
 end

--- a/lib/tasks/dev.rake
+++ b/lib/tasks/dev.rake
@@ -97,8 +97,8 @@ unless ENV['RAILS_ENV'] == "production"
 
       # You may want to follow up with:
       # rake chf:user:test:create[somebody@chemheritage.org,password] chf:admin:grant[somebody@chemheritage.org]
-      desc "Reset db, solr, and fedora, and proper setup for blank slate"
-      task :all => [:solr, :fedora, :derivatives, :redis, "db:reset"]  do
+      desc "Reset db, solr, fedora, some caches, and proper setup for blank slate"
+      task :all => [:solr, :fedora, :derivatives, :redis, "db:reset", "chf:riiif:clear_caches"]  do
         Rake::Task['curation_concerns:workflow:load'].invoke
         Rake::Task['sufia:default_admin_set:create'].invoke
       end

--- a/spec/models/chf/env_spec.rb
+++ b/spec/models/chf/env_spec.rb
@@ -1,0 +1,48 @@
+require 'spec_helper'
+
+describe CHF::Env do
+  let(:test_key) { :some_key }
+  let(:env_value) { "env_value" }
+  let(:conf_value) { "conf_value" }
+  let(:default_value) { "default_value"}
+  let(:instance) do
+    CHF::Env.new.tap do |e|
+      e.define_key test_key, default: default_value
+    end
+  end
+
+  describe "from ENV" do
+    before do
+      stub_const('ENV', ENV.to_hash.merge(test_key.to_s.upcase => env_value))
+      allow(instance).to receive(:load_yaml_file).and_return(test_key.to_s => conf_value)
+    end
+
+    it "takes priority" do
+      expect(instance.lookup(test_key)).to eq(env_value)
+    end
+  end
+
+  describe "from conf_file" do
+    before do
+      allow(instance).to receive(:load_yaml_file).and_return(test_key.to_s => conf_value)
+    end
+    it "returns from conf file" do
+      expect(instance.lookup(test_key)).to eq conf_value
+    end
+  end
+
+  describe "from default" do
+    it "returns simple default" do
+      expect(instance.lookup(test_key)).to eq(default_value)
+    end
+    describe "with lambda" do
+      before do
+        instance.define_key test_key, default: -> { "default_from_lambda" }
+      end
+      it "returns lambda result" do
+        expect(instance.lookup(test_key)).to eq("default_from_lambda")
+      end
+    end
+  end
+
+end


### PR DESCRIPTION
This pulls from the config/local_env.yml if it's present. 

BUT it lets you override that with actual ENV -- awfully useful for testing in dev to make
sure it works how you want in different setings. Also useful if we want to deploy
the app to another environment like heroku that actually uses ENV. 

And it also lets you set a default value, including as a lambda using other env
or config, for us to set our default dev values, or calculate values that aren't
yet in our local_env.yml as independent values. 

The actual implementation of CHF::Env is a bit hacky, although not too complicated,
but I think the API/semantics are pretty good and should be pretty stable. 

In addition, this PR then uses the new CHF::Env for:

* public_riiif_url
* setting riiif file cache paths, with the defaults that we want (there is also
  clear riiif file caches rake task)
* turning on routing of riiif/app paths with defaults that will still
  route everything in dev or if otherwise unset, but route only
  the right things if `service_level` is properly set.