### PR TITLE
Empty child fix

### DIFF
--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -123,5 +123,8 @@ class SolrDocument
     # should be a single value but sometimes comes back as an array not sure why
     Array.wrap(self[Solrizer.solr_name('original_file_id')]).first
   end
+  def thumbnail_path
+    self['thumbnail_path_ss']
+  end
 
 end

--- a/app/presenters/curation_concerns/generic_work_show_presenter.rb
+++ b/app/presenters/curation_concerns/generic_work_show_presenter.rb
@@ -9,7 +9,7 @@ module CurationConcerns
       :extent, :division, :series_arrangement, :rights_holder,
       :credit_line, :additional_credit, :file_creator, :admin_note,
       :inscription, :date_of_work, :engraver, :printer,
-      :printer_of_plates, :after,
+      :printer_of_plates, :after, :thumbnail_path,
       to: :solr_document
 
     def additional_title

--- a/app/views/curation_concerns/base/_chf_image_viewer.html.erb
+++ b/app/views/curation_concerns/base/_chf_image_viewer.html.erb
@@ -54,7 +54,7 @@
                       member_dl_jpeg_url: riiif_image_url(member_presenter.riiif_file_id, format: "jpg", size: "full"),
                       tile_source: riiif_info_url(member_presenter.riiif_file_id),
                       src: member_presenter.first(blacklight_config.view_config(document_index_view_type).thumbnail_field)
-                    }
+                    } if member_presenter.riiif_file_id # don't show it in the viewer if there's no image
                 -%>
               <%- end -%>
             <% end %>

--- a/app/views/curation_concerns/base/_show_page_image.html.erb
+++ b/app/views/curation_concerns/base/_show_page_image.html.erb
@@ -18,12 +18,19 @@
 <%= content_tag("div",
       tabindex: "0",
       data: {
-        trigger: "chf_image_viewer",
+        # only trigger the viewer if there's an image to show in it
+        trigger: member.riiif_file_id ? "chf_image_viewer" : "",
         member_id: member.representative_id
       },
       class: ["show-page-image"] + Array(local_assigns[:extra_classes])) do
 %>
-    <% if local_assigns[:lazy_after] && member_counter > local_assigns[:lazy_after] - 1 %>
+    <% if member.riiif_file_id.nil? %>
+      <%# if there's no image, show the default thumbnail (it gets indexed) %>
+      <%= image_tag member.thumbnail_path,
+                    class: "show-page-image-image",
+                    alt: ""
+      %>
+    <% elsif local_assigns[:lazy_after] && member_counter > local_assigns[:lazy_after] - 1 %>
       <%= image_tag nil,
                     class: "lazyload show-page-image-image",
                     alt: "",

--- a/spec/helpers/riiif_helper_spec.rb
+++ b/spec/helpers/riiif_helper_spec.rb
@@ -1,14 +1,6 @@
 require 'rails_helper'
 
 describe RiiifHelper do
-  def riiif_info_url (riiif_file_id)
-    path = riiif.info_path(riiif_file_id, locale: nil)
-    if CHF::Env.lookup(:public_riiif_url)
-      return Addressable::URI.join(CHF::Env.lookup(:public_riiif_url), path).to_s
-    else
-      return path
-    end
-  end
   describe "#riiif_info_url" do
     context "riiif uses localhost" do
       it "provides relative path" do


### PR DESCRIPTION
I tried this 2 ways; this way seemed a little messy but it works.

The other (see https://github.com/chemheritage/chf-sufia/commit/b8f199e7551a6c4b5ef15bfd8b724cd0e55497e1 on branch empty-child-fix-2) was an attempt to handle it as much as possible in the helper, but it resulted in the viewer failing to show the default thumb, plus there was still a new conditional needed in the download link logic.