### PR TITLE
lazysizes-aspectratio on all show page images and viewer thumbs

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -12,6 +12,11 @@
 
 //= require jquery
 //= require jquery_ujs
+
+// Needs to load BEFORE we load anything that loads AMD/almond, which sufia
+// does, or the presence of AMD in a non-AMD aware build tool confuses aspectratio.
+//= require 'lazysizes/plugins/aspectratio/ls.aspectratio.js'
+
 //= require dataTables/jquery.dataTables
 //= require dataTables/bootstrap/3/jquery.dataTables.bootstrap
 // Required by Blacklight
@@ -33,4 +38,6 @@
 // this:
 //= require 'blacklight_range_limit'
 
-//= require 'lazysizes.js'
+
+//= require 'lazysizes'
+

--- a/app/assets/stylesheets/local/chf_image_viewer.scss
+++ b/app/assets/stylesheets/local/chf_image_viewer.scss
@@ -288,8 +288,6 @@
       &.lazyload, &.lazyloading, &.lazyload {
         background: #AAA asset-url('spinner.svg') no-repeat center;
         background-size: 34px 34px;
-        width: 60px;
-        height: 80px;
       }
     }
   }

--- a/app/assets/stylesheets/local/show.scss
+++ b/app/assets/stylesheets/local/show.scss
@@ -154,7 +154,6 @@
         width: 100%;
         &.lazyload, &.lazyloading {
           background: #AAA asset-url('spinner.svg') no-repeat center;
-          height: calc(1.33 * 160px);
         }
         vertical-align: bottom;
         // keep crazy long aspect ratio images from being
@@ -166,17 +165,10 @@
       @media (min-width: $screen-sm-min) {
         // 2 wide
         width: calc(50% / 2 - 12px);
-        // before lazy loaded complete, VERY roughy estimate 4/3 aspect ratio ish
-        img.lazyload, img.lazyloading {
-          height: 25vw;
-        }
       }
       @media (min-width: $screen-lg-min) {
         // 3 wide
         width: calc(50% / 3 - 10px);
-        img.lazyload, img.lazyloading {
-          height: 15vw;
-        }
       }
     }
   }

--- a/app/presenters/chf/file_set_presenter.rb
+++ b/app/presenters/chf/file_set_presenter.rb
@@ -19,5 +19,14 @@ module CHF
         return FileSet.find(id).original_file.id
       end
     end
+
+    def representative_height
+      height
+    end
+
+    def representative_width
+      width
+    end
+
   end
 end

--- a/app/presenters/curation_concerns/generic_work_show_presenter.rb
+++ b/app/presenters/curation_concerns/generic_work_show_presenter.rb
@@ -83,5 +83,15 @@ module CurationConcerns
       return if representative_presenter.nil?
       representative_presenter.riiif_file_id
     end
+
+    def representative_height
+      return if representative_presenter.nil?
+      representative_presenter.height
+    end
+
+    def representative_width
+      return if representative_presenter.nil?
+      representative_presenter.width
+    end
   end
 end

--- a/app/views/curation_concerns/base/_chf_image_viewer.html.erb
+++ b/app/views/curation_concerns/base/_chf_image_viewer.html.erb
@@ -44,6 +44,7 @@
                     tabindex: "0",
                     role: "button",
                     data: {
+                      aspectratio: "#{member_presenter.representative_width}/#{member_presenter.representative_height}", # used for lazysizes-aspectratio
                       trigger: 'change-viewer-source',
                       index: i + 1,
                       title: member_presenter.link_name,

--- a/app/views/curation_concerns/base/_show_page_image.html.erb
+++ b/app/views/curation_concerns/base/_show_page_image.html.erb
@@ -35,6 +35,7 @@
                     class: "lazyload show-page-image-image",
                     alt: "",
                     data: {
+                      aspectratio: "#{member.representative_width}/#{member.representative_height}", # used for lazysizes-aspectratio
                       src: riiif_image_url(member.riiif_file_id, format: "jpg", size: "#{base_width},"),
                       srcset: riiif_image_srcset_pixel_density(member.riiif_file_id, base_width)
                     }
@@ -45,6 +46,7 @@
                     srcset: riiif_image_srcset_pixel_density(member.riiif_file_id, base_width),
                     alt: "",
                     data: {
+                      aspectratio: "#{member.representative_width}/#{member.representative_height}", # used for lazysizes-aspectratio
                       trigger: "chf_image_viewer",
                       member_id: member.id
                     }


### PR DESCRIPTION
Takes up proper space on page even before image has loaded, since we tell it expected
aspect ratio, gotten from recorded characterization.

works whether the images is being lazy loaded or normal loaded, nice!
lazysizes-aspectratio is a nice script.

Closes #669