### PR TITLE
Resque should only restart on a bg jobs machine

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -49,7 +49,7 @@ namespace :chf do
   # Restart resque-pool.
   desc "Restart resque-pool"
   task :resquepoolrestart do
-    on roles(:app) do
+    on roles(:jobs) do
       execute :sudo, "/usr/sbin/service resque-pool restart"
     end
   end


### PR DESCRIPTION
This keeps the riif box from trying to run the resque-pool init script.