### PR TITLE
Sort out google analytics semantics, pass desired data; fixes #668

### DIFF
--- a/app/assets/javascripts/chf_ga_events.js
+++ b/app/assets/javascripts/chf_ga_events.js
@@ -5,9 +5,10 @@
 //
 // https://developers.google.com/analytics/devguides/collection/gajs/eventTrackerGuide
 
-$(document).on('click', '*[data-analytics-event]', function(e) {
+$(document).on('click', '*[data-analytics-category]', function(e) {
   _gaq.push(['_trackEvent',
-             e.target.getAttribute("data-analytics-event"),
+             e.target.getAttribute("data-analytics-category"),
+             e.target.getAttribute("data-analytics-action"),
              e.target.getAttribute("data-analytics-label"),
              e.target.getAttribute("data-analytics-value")
             ]);

--- a/app/assets/javascripts/chf_image_viewer.js
+++ b/app/assets/javascripts/chf_image_viewer.js
@@ -451,13 +451,6 @@ jQuery(document).ready(function($) {
       event.preventDefault();
       var id = this.getAttribute('data-member-id');
       chf_image_viewer().show(id);
-
-      // GA
-      _gaq.push(['_trackEvent',
-           'ImageViewer',
-           'fileSetId',
-           id
-          ]);
     });
 
     // with keyboard-tab nav to our thumbs, let return/space trigger click as for normal links

--- a/app/helpers/riiif_helper.rb
+++ b/app/helpers/riiif_helper.rb
@@ -38,7 +38,7 @@ module RiiifHelper
   #
   # if use_image_server is false, size_key is ignored and no srcsets are generated,
   # we just use the stock hydra-derivative created image labelled 'jpeg'
-  def member_image_tag(parent_id, member, size_key: nil, lazy: false, use_image_server: CHF::Env.lookup(:use_image_server_on_show_page))
+  def member_image_tag(parent_id:, member:, size_key: nil, lazy: false, use_image_server: CHF::Env.lookup(:use_image_server_on_show_page))
     base_width = size_key == :large ? 525 : 208
 
     args = {

--- a/app/helpers/riiif_helper.rb
+++ b/app/helpers/riiif_helper.rb
@@ -38,7 +38,7 @@ module RiiifHelper
   #
   # if use_image_server is false, size_key is ignored and no srcsets are generated,
   # we just use the stock hydra-derivative created image labelled 'jpeg'
-  def member_image_tag(member, size_key: nil, lazy: false, use_image_server: CHF::Env.lookup(:use_image_server_on_show_page))
+  def member_image_tag(parent_id, member, size_key: nil, lazy: false, use_image_server: CHF::Env.lookup(:use_image_server_on_show_page))
     base_width = size_key == :large ? 525 : 208
 
     args = {
@@ -48,6 +48,9 @@ module RiiifHelper
         trigger: "chf_image_viewer",
         member_id: member.id,
         aspectratio: "#{member.representative_width}/#{member.representative_height}", # used for lazysizes-aspectratio
+        analytics_category: "Work",
+        analytics_action: "view",
+        analytics_label: parent_id
       }
     }
 

--- a/app/views/curation_concerns/base/_chf_download_menu.html.erb
+++ b/app/views/curation_concerns/base/_chf_download_menu.html.erb
@@ -24,12 +24,11 @@ locals:
                   id: "file_download",
                   data: {
                     content_hook: "dl-original-link",
-                    label: (member.id if member),
                     # These action/labels are what sufia/hyrax uses, although
                     # a bit weird. https://github.com/samvera/hyrax/blob/1e504c200fd9c39120f514ac33cd42cd843de9fa/app/assets/javascripts/hyrax/ga_events.js
-                    analytics_event: "Files",
-                    analytics_label: "Downloaded",
-                    analytics_value: (member.representative_id if member)
+                    analytics_category: "Work",
+                    analytics_action: "download-tiff",
+                    analytics_label: parent.id
                   }) %>
     </li>
     <li>
@@ -40,9 +39,9 @@ locals:
                     content_hook: "dl-jpeg-link",
                     # These action/labels are based on what sufia/hyrax uses, although
                     # a bit weird.
-                    analytics_event: "Files",
-                    analytics_label: "Downloaded-jpg",
-                    analytics_value: (member.representative_id if member)
+                    analytics_category: "Work",
+                    analytics_action: "download-jpg",
+                    analytics_label: parent.id
                   }) %>
     </li>
   </ul>

--- a/app/views/curation_concerns/base/_show_page_image.html.erb
+++ b/app/views/curation_concerns/base/_show_page_image.html.erb
@@ -20,7 +20,7 @@
       class: ["show-page-image"] + Array(local_assigns[:extra_classes])) do
 %>
 
-    <%= member_image_tag(member,
+    <%= member_image_tag(@presenter.id, member,
                          size_key: local_assigns[:size],
                          lazy: (local_assigns[:lazy_after] && member_counter > local_assigns[:lazy_after] - 1))
     %>

--- a/app/views/curation_concerns/base/_show_page_image.html.erb
+++ b/app/views/curation_concerns/base/_show_page_image.html.erb
@@ -20,7 +20,7 @@
       class: ["show-page-image"] + Array(local_assigns[:extra_classes])) do
 %>
 
-    <%= member_image_tag(@presenter.id, member,
+    <%= member_image_tag(parent_id: @presenter.id, member: member,
                          size_key: local_assigns[:size],
                          lazy: (local_assigns[:lazy_after] && member_counter > local_assigns[:lazy_after] - 1))
     %>


### PR DESCRIPTION
Variable names in the generalized javascript have been changed to match google analytics. The generalized js now requires a class, and looks up the element's hierarchy to find it if it's not on the target element. This allows the container div to hold the ga data, but still use the generalized javascript.