### PR TITLE
App will use images on show page from riiif or hydra-derivative 'jpeg' depending on config

### DIFF
--- a/app/helpers/riiif_helper.rb
+++ b/app/helpers/riiif_helper.rb
@@ -48,7 +48,10 @@ module RiiifHelper
       }
     }
 
-    if lazy
+    if member.riiif_file_id.nil?
+      # if there's no image, show the default thumbnail (it gets indexed)
+      args[:src] = member.thumbnail_path
+    elsif lazy
       args[:class] << "lazyload"
       args[:data][:src]    = riiif_image_url(member.riiif_file_id, format: "jpg", size: "#{base_width},")
       args[:data][:srcset] = riiif_image_srcset_pixel_density(member.riiif_file_id, base_width)

--- a/app/helpers/riiif_helper.rb
+++ b/app/helpers/riiif_helper.rb
@@ -31,6 +31,35 @@ module RiiifHelper
     end.join(", ")
   end
 
+  # create an image tag for a 'member' (could be fileset or child work) thumb,
+  # for use on show page. Calculates proper image tag based on lazy or not,
+  # use of riiif for images or not, and desired size. Includes proper
+  # attributes for triggering viewer, analytics, etc.
+  def member_image_tag(member, size_key: nil, lazy: false)
+    base_width = size_key == :large ? 525 : 208
+
+    args = {
+      class: ["show-page-image-image"],
+      alt: "",
+      data: {
+        trigger: "chf_image_viewer",
+        member_id: member.id,
+        aspectratio: "#{member.representative_width}/#{member.representative_height}", # used for lazysizes-aspectratio
+      }
+    }
+
+    if lazy
+      args[:class] << "lazyload"
+      args[:data][:src]    = riiif_image_url(member.riiif_file_id, format: "jpg", size: "#{base_width},")
+      args[:data][:srcset] = riiif_image_srcset_pixel_density(member.riiif_file_id, base_width)
+    else
+      args[:src]    = riiif_image_url(member.riiif_file_id, format: "jpg", size: "#{base_width},")
+      args[:srcset] = riiif_image_srcset_pixel_density(member.riiif_file_id, base_width)
+    end
+
+    image_tag(args.delete(:src), args)
+  end
+
   private
 
   def create_riiif_url(path)

--- a/app/helpers/riiif_helper.rb
+++ b/app/helpers/riiif_helper.rb
@@ -36,9 +36,9 @@ module RiiifHelper
   # use of riiif for images or not, and desired size. Includes proper
   # attributes for triggering viewer, analytics, etc.
   #
-  # if use_riiif is false, size_key is ignored and no srcsets are generated,
+  # if use_image_server is false, size_key is ignored and no srcsets are generated,
   # we just use the stock hydra-derivative created image labelled 'jpeg'
-  def member_image_tag(member, size_key: nil, lazy: false)
+  def member_image_tag(member, size_key: nil, lazy: false, use_image_server: true)
     base_width = size_key == :large ? 525 : 208
 
     args = {
@@ -53,11 +53,17 @@ module RiiifHelper
 
     src_args = if member.riiif_file_id.nil?
       # if there's no image, show the default thumbnail (it gets indexed)
-      { src:  member.thumbnail_path }
-    else
+      {
+        src:  member.thumbnail_path
+      }
+    elsif use_image_server
       {
         src: riiif_image_url(member.riiif_file_id, format: "jpg", size: "#{base_width},"),
         srcset: riiif_image_srcset_pixel_density(member.riiif_file_id, base_width)
+      }
+    else
+      {
+        src: main_app.download_path(member.representative_id, file: "jpeg")
       }
     end
 

--- a/app/helpers/riiif_helper.rb
+++ b/app/helpers/riiif_helper.rb
@@ -38,7 +38,7 @@ module RiiifHelper
   #
   # if use_image_server is false, size_key is ignored and no srcsets are generated,
   # we just use the stock hydra-derivative created image labelled 'jpeg'
-  def member_image_tag(member, size_key: nil, lazy: false, use_image_server: true)
+  def member_image_tag(member, size_key: nil, lazy: false, use_image_server: CHF::Env.lookup(:use_image_server_on_show_page))
     base_width = size_key == :large ? 525 : 208
 
     args = {

--- a/app/models/chf/env.rb
+++ b/app/models/chf/env.rb
@@ -137,6 +137,10 @@ module CHF
     define_key :app_role
     define_key :service_level
 
+    define_key :use_image_server_on_show_page,
+      system_env_transform: BOOLEAN_TRANSFORM,
+      default: -> { true }
+
     define_key :riiif_originals_cache, default: -> {
       Rails.env.production? ? "/var/sufia/riiif-originals" : Rails.root.join("tmp", "riiif-originals").to_s
     }

--- a/app/views/curation_concerns/base/_show_page_image.html.erb
+++ b/app/views/curation_concerns/base/_show_page_image.html.erb
@@ -30,27 +30,11 @@
                     class: "show-page-image-image",
                     alt: ""
       %>
-    <% elsif local_assigns[:lazy_after] && member_counter > local_assigns[:lazy_after] - 1 %>
-      <%= image_tag nil,
-                    class: "lazyload show-page-image-image",
-                    alt: "",
-                    data: {
-                      aspectratio: "#{member.representative_width}/#{member.representative_height}", # used for lazysizes-aspectratio
-                      src: riiif_image_url(member.riiif_file_id, format: "jpg", size: "#{base_width},"),
-                      srcset: riiif_image_srcset_pixel_density(member.riiif_file_id, base_width)
-                    }
-      %>
     <% else %>
-      <%= image_tag riiif_image_url(member.riiif_file_id, format: "jpg", size: "#{base_width},"),
-                    class: "show-page-image-image",
-                    srcset: riiif_image_srcset_pixel_density(member.riiif_file_id, base_width),
-                    alt: "",
-                    data: {
-                      aspectratio: "#{member.representative_width}/#{member.representative_height}", # used for lazysizes-aspectratio
-                      trigger: "chf_image_viewer",
-                      member_id: member.id
-                    }
-      %>
+      <%= member_image_tag(member,
+                           size_key: local_assigns[:size],
+                           lazy: (local_assigns[:lazy_after] && member_counter > local_assigns[:lazy_after] - 1))
+       %>
     <% end %>
 
     <% if current_ability.current_user.staff? || member.model_name.singular.to_sym != :file_set %>

--- a/app/views/curation_concerns/base/_show_page_image.html.erb
+++ b/app/views/curation_concerns/base/_show_page_image.html.erb
@@ -17,11 +17,6 @@
 %>
 <%= content_tag("div",
       tabindex: "0",
-      data: {
-        # only trigger the viewer if there's an image to show in it
-        trigger: member.riiif_file_id ? "chf_image_viewer" : "",
-        member_id: member.representative_id
-      },
       class: ["show-page-image"] + Array(local_assigns[:extra_classes])) do
 %>
 

--- a/app/views/curation_concerns/base/_show_page_image.html.erb
+++ b/app/views/curation_concerns/base/_show_page_image.html.erb
@@ -24,18 +24,11 @@
       },
       class: ["show-page-image"] + Array(local_assigns[:extra_classes])) do
 %>
-    <% if member.riiif_file_id.nil? %>
-      <%# if there's no image, show the default thumbnail (it gets indexed) %>
-      <%= image_tag member.thumbnail_path,
-                    class: "show-page-image-image",
-                    alt: ""
-      %>
-    <% else %>
-      <%= member_image_tag(member,
-                           size_key: local_assigns[:size],
-                           lazy: (local_assigns[:lazy_after] && member_counter > local_assigns[:lazy_after] - 1))
-       %>
-    <% end %>
+
+    <%= member_image_tag(member,
+                         size_key: local_assigns[:size],
+                         lazy: (local_assigns[:lazy_after] && member_counter > local_assigns[:lazy_after] - 1))
+    %>
 
     <% if current_ability.current_user.staff? || member.model_name.singular.to_sym != :file_set %>
       <div class="show-page-member-title">

--- a/spec/models/chf/env_spec.rb
+++ b/spec/models/chf/env_spec.rb
@@ -63,4 +63,18 @@ describe CHF::Env do
       end
     end
   end
+
+  describe "booelan transform from ENV" do
+    let(:instance) do
+      CHF::Env.new.tap do |e|
+        e.define_key test_key, default: default_value, system_env_transform: CHF::Env::BOOLEAN_TRANSFORM
+      end
+    end
+    before do
+      stub_const('ENV', ENV.to_hash.merge(test_key.to_s.upcase => "true"))
+    end
+    it "converts to boolean" do
+      expect(instance.lookup(test_key)).to eq true
+    end
+  end
 end


### PR DESCRIPTION
To accomplish, also refactored _show_page_image image tag generation to a
unified member_image_tag helper. Which will make it easier to do the GA
stuff in #668

Currently defaults to using riiif. If we don't want to use riiif, we could
change the default, or just add a key in local_env.yml,

    use_image_server_on_show_page: false

You can experiment in dev to see both modes by starting up as:

    USE_IMAGE_SERVER_ON_SHOW_PAGE=false rails server
    USE_IMAGE_SERVER_ON_SHOW_PAGE=true rails server

Closes #686