### PR TITLE
CHF::Env feature flags to turn off riiif use on viewer and download link

### DIFF
--- a/app/models/chf/env.rb
+++ b/app/models/chf/env.rb
@@ -139,15 +139,15 @@ module CHF
 
     define_key :use_image_server_on_show_page,
       system_env_transform: BOOLEAN_TRANSFORM,
-      default: -> { true }
+      default: -> { false }
 
     define_key :use_image_server_on_viewer,
       system_env_transform: BOOLEAN_TRANSFORM,
-      default: -> { true }
+      default: -> { false }
 
     define_key :use_image_server_downloads,
       system_env_transform: BOOLEAN_TRANSFORM,
-      default: -> { true }
+      default: -> { false }
 
 
     define_key :riiif_originals_cache, default: -> {

--- a/app/models/chf/env.rb
+++ b/app/models/chf/env.rb
@@ -141,6 +141,15 @@ module CHF
       system_env_transform: BOOLEAN_TRANSFORM,
       default: -> { true }
 
+    define_key :use_image_server_on_viewer,
+      system_env_transform: BOOLEAN_TRANSFORM,
+      default: -> { true }
+
+    define_key :use_image_server_downloads,
+      system_env_transform: BOOLEAN_TRANSFORM,
+      default: -> { true }
+
+
     define_key :riiif_originals_cache, default: -> {
       Rails.env.production? ? "/var/sufia/riiif-originals" : Rails.root.join("tmp", "riiif-originals").to_s
     }

--- a/app/models/chf/env.rb
+++ b/app/models/chf/env.rb
@@ -162,12 +162,16 @@ module CHF
     # but for now we calculate based on app_role value, but do it here
     # so we have one place to change.
     # Can still override with ENV or local_env.yml locally, nice!
-    define_key :serve_riiif_paths, default: -> {
-      lookup(:app_role).blank? || lookup(:app_role) == "riiif"
-    }
-    define_key :serve_app_paths, default: -> {
-      lookup(:app_role).blank? || lookup(:app_role) == "app"
-    }
+    define_key :serve_riiif_paths,
+      system_env_transform: BOOLEAN_TRANSFORM,
+      default: -> {
+        lookup(:app_role).blank? || lookup(:app_role) == "riiif"
+      }
+    define_key :serve_app_paths,
+      system_env_transform: BOOLEAN_TRANSFORM,
+      default: -> {
+        lookup(:app_role).blank? || lookup(:app_role) == "app"
+      }
 
   end
 end

--- a/app/views/curation_concerns/base/_chf_download_menu.html.erb
+++ b/app/views/curation_concerns/base/_chf_download_menu.html.erb
@@ -32,18 +32,21 @@ locals:
                     analytics_value: (member.representative_id if member)
                   }) %>
     </li>
-    <li>
-      <%= link_to("Full-size JPEG",
-                  (member ? riiif_image_url(member.riiif_file_id, format: "jpg", size: "full") : "#"),
-                  target: "_new",
-                  data: {
-                    content_hook: "dl-jpeg-link",
-                    # These action/labels are based on what sufia/hyrax uses, although
-                    # a bit weird.
-                    analytics_event: "Files",
-                    analytics_label: "Downloaded-jpg",
-                    analytics_value: (member.representative_id if member)
-                  }) %>
-    </li>
+
+    <% if CHF::Env.lookup(:use_image_server_downloads) %>
+      <li>
+        <%= link_to("Full-size JPEG",
+                    (member ? riiif_image_url(member.riiif_file_id, format: "jpg", size: "full") : "#"),
+                    target: "_new",
+                    data: {
+                      content_hook: "dl-jpeg-link",
+                      # These action/labels are based on what sufia/hyrax uses, although
+                      # a bit weird.
+                      analytics_event: "Files",
+                      analytics_label: "Downloaded-jpg",
+                      analytics_value: (member.representative_id if member)
+                    }) %>
+      </li>
+    <% end %>
   </ul>
 

--- a/app/views/curation_concerns/base/_chf_image_viewer.html.erb
+++ b/app/views/curation_concerns/base/_chf_image_viewer.html.erb
@@ -53,7 +53,11 @@
                       member_show_url: contextual_path(member_presenter, work),
                       member_dl_original_url: main_app.download_path(member_presenter.representative_id),
                       member_dl_jpeg_url: riiif_image_url(member_presenter.riiif_file_id, format: "jpg", size: "full"),
-                      tile_source: riiif_info_url(member_presenter.riiif_file_id),
+                      tile_source: (if CHF::Env.lookup(:use_image_server_on_viewer)
+                                      riiif_info_url(member_presenter.riiif_file_id)
+                                    else
+                                      {"type" => "image", "url" => main_app.download_path(member_presenter.representative_id, file: "jpeg")}.to_json
+                                    end),
                       src: member_presenter.first(blacklight_config.view_config(document_index_view_type).thumbnail_field)
                     } if member_presenter.riiif_file_id # don't show it in the viewer if there's no image
                 -%>

--- a/app/views/curation_concerns/base/_chf_image_viewer.html.erb
+++ b/app/views/curation_concerns/base/_chf_image_viewer.html.erb
@@ -52,7 +52,9 @@
                       member_id: member_presenter.representative_id,
                       member_show_url: contextual_path(member_presenter, work),
                       member_dl_original_url: main_app.download_path(member_presenter.representative_id),
-                      member_dl_jpeg_url: riiif_image_url(member_presenter.riiif_file_id, format: "jpg", size: "full"),
+                      member_dl_jpeg_url: (if CHF::Env.lookup(:use_image_server_downloads)
+                                            riiif_image_url(member_presenter.riiif_file_id, format: "jpg", size: "full")
+                                          end),
                       tile_source: (if CHF::Env.lookup(:use_image_server_on_viewer)
                                       riiif_info_url(member_presenter.riiif_file_id)
                                     else


### PR DESCRIPTION
All riiif use feature flags DEFAULT false now.

To verify everything is working with no riiif server in dev, you could:

    SERVE_RIIIF_PATHS=false rails server

If you wanted to turn on riiif features in dev, you could:

    USE_IMAGE_SERVER_ON_SHOW_PAGE=true USE_IMAGE_SERVER_DOWNLOADS=true USE_IMAGE_SERVER_ON_VIEWER=true rails server

All feature flags also can be controlled from local_env.yml but they are all currently
defaulting false.