### PR TITLE
look up rights metadata for rights statements faster

### DIFF
--- a/app/models/chf/rights_terms.rb
+++ b/app/models/chf/rights_terms.rb
@@ -25,10 +25,14 @@ module CHF
       metadata_for(id).try { |h| h["short_label_html"] }
     end
 
+    # A global/default instance of this object, a singleton-like
+    # pattern, but we aren't enforcing only one object can exist.
     def self.global
       @global ||= self.new
     end
 
+    # This weird code was what I ame up with to succesfully use Rails
+    # 'delegate' to the #global class method containing a global instance.
     class << self
       delegate :metadata_for, :category_for, :short_label_html_for, to: :global
     end
@@ -36,6 +40,8 @@ module CHF
     private
 
     def terms_by_id
+      # from the array of term hashes, to an array of [id, term_hash], that
+      # can be turned into a hash keyded on `id`, by using Array#to_h
       @terms_by_id ||= YAML.load(File.read(@yaml_file_path))["terms"].collect do |hash|
                         [hash["id"], hash]
                       end.to_h

--- a/app/models/chf/rights_terms.rb
+++ b/app/models/chf/rights_terms.rb
@@ -1,0 +1,45 @@
+module CHF
+  # Looks up info from config/authorities/license.yml, which is used by
+  # QuestioningAuthority.  The QA logic for accessing it had some serious
+  # performance problems being used as much as it was -- not caching YML, architected
+  # in a way that makes it hard to fix to cache YML. So we write our own simple cover.
+  #
+  #     RightsTerms.category_for("http://rightsstatements.org/vocab/InC-OW-EU/1.0/")
+  #     RightsTerms.short_label_html_for("http://rightsstatements.org/vocab/InC-OW-EU/1.0/")
+  #     RightsTerms.metadata_for("http://rightsstatements.org/vocab/InC-OW-EU/1.0/")
+  class RightsTerms
+
+    def initialize(yaml_file_path = Rails.root.join("config/authorities/licenses.yml"))
+      @yaml_file_path = yaml_file_path
+    end
+
+    def metadata_for(id)
+      terms_by_id[id]
+    end
+
+    def category_for(id)
+      metadata_for(id).try { |h| h["category"] }
+    end
+
+    def short_label_html_for(id)
+      metadata_for(id).try { |h| h["short_label_html"] }
+    end
+
+    def self.global
+      @global ||= self.new
+    end
+
+    class << self
+      delegate :metadata_for, :category_for, :short_label_html_for, to: :global
+    end
+
+    private
+
+    def terms_by_id
+      @terms_by_id ||= YAML.load(File.read(@yaml_file_path))["terms"].collect do |hash|
+                        [hash["id"], hash]
+                      end.to_h
+    end
+
+  end
+end

--- a/app/presenters/curation_concerns/generic_work_show_presenter.rb
+++ b/app/presenters/curation_concerns/generic_work_show_presenter.rb
@@ -22,8 +22,9 @@ module CurationConcerns
 
     def rights_icon(identifier = rights.first)
       # schema allows multiple rights, we only use one.
-      # we have added our own metadata to the liceneses.yml that the CC
-      # class doens't really have accessors for, we'll kinda hack it.
+      # we have added our own metadata to the licenses.yml used by
+      # CC/QA, but the CC/QA code makes it difficult to access
+      # efficiently, so we use our own CHF::RightsTerms
       case CHF::RightsTerms.category_for(identifier)
         when "in_copyright"
           "rightsstatements-InC.Icon-Only.dark.svg"

--- a/app/presenters/curation_concerns/generic_work_show_presenter.rb
+++ b/app/presenters/curation_concerns/generic_work_show_presenter.rb
@@ -24,15 +24,15 @@ module CurationConcerns
       # schema allows multiple rights, we only use one.
       # we have added our own metadata to the liceneses.yml that the CC
       # class doens't really have accessors for, we'll kinda hack it.
-      case CurationConcerns::LicenseService.new.authority.find(identifier).fetch("category", nil)
-      when "in_copyright"
-        "rightsstatements-InC.Icon-Only.dark.svg"
-      when "no_copyright"
-        "rightsstatements-NoC.Icon-Only.dark.svg"
-      else
-        "rightsstatements-Other.Icon-Only.dark.svg"
+      case CHF::RightsTerms.category_for(identifier)
+        when "in_copyright"
+          "rightsstatements-InC.Icon-Only.dark.svg"
+        when "no_copyright"
+          "rightsstatements-NoC.Icon-Only.dark.svg"
+        else
+          "rightsstatements-Other.Icon-Only.dark.svg"
+        end
       end
-    end
 
     def rights_url(identifier = rights.first)
       # we use resolvable urls already
@@ -42,7 +42,7 @@ module CurationConcerns
     def rights_icon_label(identifier = rights.first)
       # we have added our own metadata to the liceneses.yml that the CC
       # class doens't really have accessors for, we'll kinda hack it.
-      CurationConcerns::LicenseService.new.authority.find(identifier).fetch("short_label_html", "").html_safe
+      (CHF::RightsTerms.short_label_html_for(identifier) || "").html_safe
     end
 
     # Override to only display if NOT open access. We assume open access, but

--- a/spec/models/chf/rights_terms_spec.rb
+++ b/spec/models/chf/rights_terms_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+
+describe CHF::RightsTerms do
+  describe "for standard id" do
+    let(:id) { "http://rightsstatements.org/vocab/InC/1.0/" }
+
+    it "can look up category" do
+      expect(described_class.category_for(id)).to be_present
+    end
+
+    it "can look up short_label_html_for" do
+      expect(described_class.short_label_html_for(id)).to be_present
+    end
+  end
+end


### PR DESCRIPTION
We were using , from QA gem.

This ended up re-loading YAML from disk on every call. Either the QA code needs caching
it doesn't have, or we're using QA wrong, or both.  Rather than figure it out,
we write our own simple wrapper to get the info from the same .yml file,
and make sure it's cached globally. Nothing fancy about this no reason
not to write ourselves.