### PR TITLE
avoid expensive application_name call

### DIFF
--- a/app/views/curation_concerns/base/_show_page_image_file_set_actions.html.erb
+++ b/app/views/curation_concerns/base/_show_page_image_file_set_actions.html.erb
@@ -32,7 +32,7 @@
     <li role="menuitem" tabindex="-1">
       <%= link_to 'Delete', polymorphic_path([main_app, file_set]),
         method: :delete, title: "Delete #{file_set}",
-        data: {confirm: "Deleting #{file_set} from #{application_name} is permanent. Click OK to delete this from #{application_name}, or Cancel to cancel this operation"} %>
+        data: {confirm: "Deleting #{file_set} is permanent. Click OK to delete this, or Cancel to cancel this operation"} %>
     </li>
   <% end %>
 


### PR DESCRIPTION
It turns out calling Sufia helper application_name is quite expensive, too
expensive to do twice per member on a page that could have hundreds of members.
Sufia::SufiaHelperBehavior#application_name

We could have tried to figure out why it was expensive and optimized it, but
we don't need it enough to be worth the time at present.

PR'd to riiif branch, because this .erb code changed it's location
between master and riiif, didn't want to deal with the merge.