### PR TITLE
inline rights_statement in _chf_download_menu

### DIFF
--- a/app/assets/stylesheets/local/show.scss
+++ b/app/assets/stylesheets/local/show.scss
@@ -173,7 +173,10 @@
   }
 }
 
-.rights-statement.inline {
+// This applies to image viewer too, where it's not inside a .work-show
+// div, so has to be out here. Sorry that it's in this .scss file, work
+// in progress.
+.rights-statement-inline {
   // turn br into space
   .rights-statement-label br {
     content: " ";

--- a/app/views/curation_concerns/base/_chf_download_menu.html.erb
+++ b/app/views/curation_concerns/base/_chf_download_menu.html.erb
@@ -14,7 +14,12 @@ locals:
 
   <ul class="dropdown-menu">
     <% if parent.has_rights_statement? %>
-      <li><%= render 'rights_statement', presenter: parent, theme: 'inline' %></li>
+      <li>
+        <%= link_to parent.rights_url, target: "_blank", class: 'rights-statement-inline' do %>
+          <%= image_tag(parent.rights_icon, class: "rights-statement-logo")  %>
+          <span class="rights-statement-label"><%= parent.rights_icon_label %></span>
+        <% end %>
+      </li>
       <li class="divider"></li>
     <% end %>
     <li class="dropdown-header">Download this image</li>


### PR DESCRIPTION
This did have significant perf impact.

Turning it into a helper instead of a partial had the same perf impact, if we wanted to keep DRY.

But I think this was a false DRY in the first place, it really IS a
different thing, the code is actually _cleaner_ with it being separate,
with it's completely own CSS class, trying to override the CSS
for the 'large' rights statement didn't make a lot of sense or make
the CSS easier to deal with. (The CSS here is still kind of a mess,
but only trying to fix what's relevant for the perf improvement here.
writing maintainable CSS is not something I'm great at yet.)

Note that all the actual heavy-lifting is done by calls to
the presenters _anyway_ (which then call out to CHF::RightsStatement
in turn).  There was just no good reason for the additional layer
of indirection/DRY in the first place, this is an all around
code improvement even aside from perf I think.

This does make me consider turning the OTHER two partials into helper
methods though, to see how that effects perf. I think we're down to perf being rails issues alone no longer sufia/samvera-related. rails is just slow at: 1) partials, and 2) generating URLs via routing. (riiif branch may generate more urls than master or certainly than stock sufia)