### PR TITLE
Avoid calling representative_presenter for each child work on a parent show page

### DIFF
--- a/app/indexers/chf/generic_work_indexer.rb
+++ b/app/indexers/chf/generic_work_indexer.rb
@@ -28,6 +28,13 @@ module CHF
           # If the thing isn't found in the license service, just ignore it.
           license_service.authority.find(id).fetch('term', nil)
         end.compact
+
+        if object.representative_id && object.representative
+          # need to index these for when it's a child work on a parent's show page
+          doc[ActiveFedora.index_field_mapper.solr_name('representative_width', type: :integer)] = object.representative.width.first if object.representative.width.present?
+          doc[ActiveFedora.index_field_mapper.solr_name('representative_height', type: :integer)] = object.representative.height.first if object.representative.height.present?
+          doc[ActiveFedora.index_field_mapper.solr_name('representative_original_file_id')] = object.representative.original_file.id if object.representative.original_file
+        end
       end
     end
 

--- a/app/presenters/curation_concerns/generic_work_show_presenter.rb
+++ b/app/presenters/curation_concerns/generic_work_show_presenter.rb
@@ -81,18 +81,15 @@ module CurationConcerns
     end
 
     def riiif_file_id
-      return if representative_presenter.nil?
-      representative_presenter.riiif_file_id
+      solr_document[ActiveFedora.index_field_mapper.solr_name('representative_original_file_id')]
     end
 
     def representative_height
-      return if representative_presenter.nil?
-      representative_presenter.height
+      solr_document[ActiveFedora.index_field_mapper.solr_name('representative_height', type: :integer)]
     end
 
     def representative_width
-      return if representative_presenter.nil?
-      representative_presenter.width
+      solr_document[ActiveFedora.index_field_mapper.solr_name('representative_width', type: :integer)]
     end
   end
 end


### PR DESCRIPTION
It results in three trips to Solr and is too expensive.

To avoid it, we index the data we need directly on the work itself.

This does seem to significantly improve performance, and is probably the cause of
our last remaining perf problem crosses fingers.

I separately PR'd the indexing changes to master. I did them here too, which
might cause a conflict on merge, but since the GenericWorkIndexer changes
paths between the branches, I was worried it might end up lost entirely
and not properly merged without a conflcit, I'd rather a conflict so
we make sure it winds up here.