### PR TITLE
improve work indexing of representative data

### DIFF
--- a/app/indexers/generic_work_indexer.rb
+++ b/app/indexers/generic_work_indexer.rb
@@ -31,6 +31,8 @@ class GenericWorkIndexer < CurationConcerns::WorkIndexer
       representative = ultimate_representative(object)
       if representative
         # need to index these for when it's a child work on a parent's show page
+        # Note corresponding code in GenericWork#update_index makes sure works using
+        # this work as a representative also get updated.
         doc[ActiveFedora.index_field_mapper.solr_name('representative_width', type: :integer)] = representative.width.first if representative.width.present?
         doc[ActiveFedora.index_field_mapper.solr_name('representative_height', type: :integer)] = representative.height.first if representative.height.present?
         doc[ActiveFedora.index_field_mapper.solr_name('representative_original_file_id')] = representative.original_file.id if representative.original_file

--- a/spec/factories/generic_works.rb
+++ b/spec/factories/generic_works.rb
@@ -64,6 +64,9 @@ FactoryGirl.define do
 
     # Real image that will resolve in a browser. It's slow cause it's going
     # through some hydra characterization, stored in fedora, etc. But it's real.
+    #
+    # Warning this fails on CI since something deep in the stack needs fits
+    # installed which we don't have on CI. Sorry. We use it in dev though. :(
     trait :real_public_image do
       transient do
         image_path { Rails.root + "spec/fixtures/sample.jpg" }
@@ -86,6 +89,8 @@ FactoryGirl.define do
     end
 
     # a public work with complete metadata and a real image! Slow.
+    # Warning this fails on CI since it uses :real_public_image and then something
+    # deep in the stack needs fits installed which we don't have on CI. Sorry. We use it in dev though. :(
     factory :full_public_work do
       with_complete_metadata
       real_public_image

--- a/spec/indexers/generic_work_indexer_spec.rb
+++ b/spec/indexers/generic_work_indexer_spec.rb
@@ -1,6 +1,13 @@
 require 'rails_helper'
 
 RSpec.describe GenericWorkIndexer do
+  before do
+    # taken from hyrax, seems to be a way to keep the deep stack from
+    # trying to call `fits` when `fits` is not avail on CI server.
+    # https://github.com/samvera/hyrax/blob/dd1c46b7a20032497b952220ade22f1e4d54b5ad/spec/features/create_work_spec.rb#L16-L17
+    allow(CharacterizeJob).to receive(:perform_later)
+  end
+
   let (:work) do
     FactoryGirl.create(:generic_work, dates_of_work: []).tap do |w|
       w.physical_container = "b2|f3|v4|p5|g234"

--- a/spec/indexers/generic_work_indexer_spec.rb
+++ b/spec/indexers/generic_work_indexer_spec.rb
@@ -104,8 +104,6 @@ RSpec.describe GenericWorkIndexer do
       end
 
       describe "when child work representative is updated" do
-        let(:new_width) { 1000 }
-        let(:new_height) { 2000 }
         let(:new_file_set) { FactoryGirl.create(:file_set, :public) }
 
         before do
@@ -126,7 +124,7 @@ RSpec.describe GenericWorkIndexer do
           child_work.save!
 
           indexed_parent = SolrDocument.find(work.id)
-          expect(indexed_parent["representative_original_file_id_tesim"]).to include(new_file_set.original_file.id)
+          expect(indexed_parent["representative_original_file_id_tesim"]).to contain_exactly(new_file_set.original_file.id)
         end
       end
     end


### PR DESCRIPTION
With tests for edge cases I could think of.
Ended up simpler code doing some TDD-ish dev, hooray.

Tricky taking care of reindexing a work when it has a child work as a representative, and that child work's representative has changed. Have to put some expensive solr lookups in indexing. 

Tests are pretty slow, maybe another 30s to these new tests. Best I could come up with so far. Wary of mocking too much stuff that I'm not super confident won't change in a future version, causing tests to false pass. 