### PR TITLE
Generalize `riiif` into `image_service` and add cantaloupe switch

### DIFF
--- a/app/helpers/image_service_helper.rb
+++ b/app/helpers/image_service_helper.rb
@@ -47,9 +47,9 @@ module ImageServiceHelper
   # any responsiveness page layout. Sends somewhat more bytes when needed at some responsive
   # sizes, but way simpler to implement; keep from asking riiiif for even more varying resizes;
   # prob good enough.
-  def riiif_image_srcset_pixel_density(riiif_file_id, base_width, format: 'jpg', quality: 'default')
+  def riiif_image_srcset_pixel_density(file_id, base_width, format: 'jpg', quality: 'default')
     [1, BigDecimal.new('1.5'), 2, 3, 4].collect do |multiplier|
-      iiif_image_url(riiif_file_id, format: "jpg", size: "#{base_width * multiplier},") + " #{multiplier}x"
+      iiif_image_url(file_id, format: "jpg", size: "#{base_width * multiplier},") + " #{multiplier}x"
     end.join(", ")
   end
 
@@ -76,15 +76,15 @@ module ImageServiceHelper
       }
     }
 
-    src_args = if member.riiif_file_id.nil?
+    src_args = if member.representative_file_id.nil?
       # if there's no image, show the default thumbnail (it gets indexed)
       {
         src:  member.thumbnail_path
       }
     elsif use_image_server
       {
-        src: iiif_image_url(member.riiif_file_id, format: "jpg", size: "#{base_width},"),
-        srcset: riiif_image_srcset_pixel_density(member.riiif_file_id, base_width)
+        src: iiif_image_url(member.representative_file_id, format: "jpg", size: "#{base_width},"),
+        srcset: riiif_image_srcset_pixel_density(member.representative_file_id, base_width)
       }
     else
       {

--- a/app/helpers/member_helper.rb
+++ b/app/helpers/member_helper.rb
@@ -52,7 +52,7 @@ module MemberHelper
     if CHF::Env.lookup(:use_image_server_downloads)
       list_elements << dropdown_menuitem(
                         link_to("Full-size JPEG",
-                          (member ? iiif_image_url(member.riiif_file_id, format: "jpg", size: "full") : "#"),
+                          (member ? iiif_image_url(member.representative_file_id, format: "jpg", size: "full") : "#"),
                           target: "_new",
                           data: {
                             content_hook: "dl-jpeg-link",

--- a/app/helpers/member_helper.rb
+++ b/app/helpers/member_helper.rb
@@ -52,7 +52,7 @@ module MemberHelper
     if CHF::Env.lookup(:use_image_server_downloads)
       list_elements << dropdown_menuitem(
                         link_to("Full-size JPEG",
-                          (member ? riiif_image_url(member.riiif_file_id, format: "jpg", size: "full") : "#"),
+                          (member ? iiif_image_url(member.riiif_file_id, format: "jpg", size: "full") : "#"),
                           target: "_new",
                           data: {
                             content_hook: "dl-jpeg-link",

--- a/app/models/chf/env.rb
+++ b/app/models/chf/env.rb
@@ -138,6 +138,7 @@ module CHF
     define_key :riiif_identify_command
     define_key :app_role
     define_key :service_level
+    define_key :image_server
 
     define_key :use_image_server_on_show_page,
       system_env_transform: BOOLEAN_TRANSFORM,

--- a/app/models/chf/env.rb
+++ b/app/models/chf/env.rb
@@ -133,7 +133,7 @@ module CHF
     ######
 
     define_key :iiif_public_url, default: '//localhost:3000/image-service'
-    define_key :internal_riiif_url
+    define_key :iiif_internal_url
     define_key :riiif_convert_command
     define_key :riiif_identify_command
     define_key :app_role

--- a/app/models/chf/env.rb
+++ b/app/models/chf/env.rb
@@ -132,7 +132,7 @@ module CHF
     #
     ######
 
-    define_key :public_riiif_url
+    define_key :iiif_public_url, default: '//localhost:3000/image-service'
     define_key :internal_riiif_url
     define_key :riiif_convert_command
     define_key :riiif_identify_command

--- a/app/presenters/chf/file_set_presenter.rb
+++ b/app/presenters/chf/file_set_presenter.rb
@@ -10,7 +10,7 @@ module CHF
       solr_document.visibility != Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
     end
 
-    def riiif_file_id
+    def representative_file_id
       # if it's not in solr, get it from fedora
       if original_file_id
         return original_file_id

--- a/app/presenters/curation_concerns/generic_work_show_presenter.rb
+++ b/app/presenters/curation_concerns/generic_work_show_presenter.rb
@@ -81,7 +81,7 @@ module CurationConcerns
     end
 
     def riiif_file_id
-      solr_document[ActiveFedora.index_field_mapper.solr_name('representative_original_file_id')]
+      Array.wrap(solr_document[ActiveFedora.index_field_mapper.solr_name('representative_original_file_id')]).first
     end
 
     def representative_height

--- a/app/presenters/curation_concerns/generic_work_show_presenter.rb
+++ b/app/presenters/curation_concerns/generic_work_show_presenter.rb
@@ -80,7 +80,7 @@ module CurationConcerns
       end
     end
 
-    def riiif_file_id
+    def representative_file_id
       Array.wrap(solr_document[ActiveFedora.index_field_mapper.solr_name('representative_original_file_id')]).first
     end
 

--- a/app/views/curation_concerns/base/_chf_image_viewer.html.erb
+++ b/app/views/curation_concerns/base/_chf_image_viewer.html.erb
@@ -53,10 +53,10 @@
                       member_show_url: contextual_path(member_presenter, work),
                       member_dl_original_url: main_app.download_path(member_presenter.representative_id),
                       member_dl_jpeg_url: (if CHF::Env.lookup(:use_image_server_downloads)
-                                            riiif_image_url(member_presenter.riiif_file_id, format: "jpg", size: "full")
+                                            iiif_image_url(member_presenter.riiif_file_id, format: "jpg", size: "full")
                                           end),
                       tile_source: (if CHF::Env.lookup(:use_image_server_on_viewer)
-                                      riiif_info_url(member_presenter.riiif_file_id)
+                                      iiif_info_url(member_presenter.riiif_file_id)
                                     else
                                       {"type" => "image", "url" => main_app.download_path(member_presenter.representative_id, file: "jpeg")}.to_json
                                     end),

--- a/app/views/curation_concerns/base/_chf_image_viewer.html.erb
+++ b/app/views/curation_concerns/base/_chf_image_viewer.html.erb
@@ -53,15 +53,15 @@
                       member_show_url: contextual_path(member_presenter, work),
                       member_dl_original_url: main_app.download_path(member_presenter.representative_id),
                       member_dl_jpeg_url: (if CHF::Env.lookup(:use_image_server_downloads)
-                                            iiif_image_url(member_presenter.riiif_file_id, format: "jpg", size: "full")
+                                            iiif_image_url(member_presenter.representative_file_id, format: "jpg", size: "full")
                                           end),
                       tile_source: (if CHF::Env.lookup(:use_image_server_on_viewer)
-                                      iiif_info_url(member_presenter.riiif_file_id)
+                                      iiif_info_url(member_presenter.representative_file_id)
                                     else
                                       {"type" => "image", "url" => main_app.download_path(member_presenter.representative_id, file: "jpeg")}.to_json
                                     end),
                       src: member_presenter.first(blacklight_config.view_config(document_index_view_type).thumbnail_field)
-                    } if member_presenter.riiif_file_id # don't show it in the viewer if there's no image
+                    } if member_presenter.representative_file_id # don't show it in the viewer if there's no image
                 -%>
               <%- end -%>
             <% end %>

--- a/lib/chf/utils/riiif_original_preloader.rb
+++ b/lib/chf/utils/riiif_original_preloader.rb
@@ -3,7 +3,7 @@ module CHF
     # Ping the riiif server with a HEAD info request for a given file id, to trigger
     # caching of original asset on riiif server.
     #
-    # You need config :internal_riiif_url set, for instance maybe INTERNAL_RIIIF_URL=http://localhost:3000
+    # You need config :iiif_internal_url set, for instance maybe IIIF_INTERNAL_URL=http://localhost:3000
     # if you really want to ping your dev server.
     #
     #     CHF::Utils::RiiifOriginalPreloader.new(file_id).ping_to_preload
@@ -13,11 +13,11 @@ module CHF
       include ImageServiceHelper
 
       attr_reader :file_id, :riiif_base
-      def initialize(file_id, riiif_base: CHF::Env.lookup(:internal_riiif_url))
+      def initialize(file_id, riiif_base: CHF::Env.lookup(:iiif_internal_url))
         @file_id = file_id
         @riiif_base = riiif_base
         unless riiif_base.present?
-          raise ArgumentError, "Need an :internal_riiif_url config. Can set in env with INTERNAL_RIIIF_URL=http://localhost:3000 or INTERNAL_RIIIF_URL=https://$internal_riiif_ip"
+          raise ArgumentError, "Need an :iiif_internal_url config. Can set in env with IIIF_INTERNAL_URL=http://localhost:3000 or IIIF_INTERNAL_URL=https://$internal_riiif_ip"
         end
       end
 

--- a/lib/chf/utils/riiif_original_preloader.rb
+++ b/lib/chf/utils/riiif_original_preloader.rb
@@ -10,7 +10,7 @@ module CHF
     #
     # NOTE: This does no auth, so will not work on non-public images
     class RiiifOriginalPreloader
-      include RiiifHelper
+      include ImageServiceHelper
 
       attr_reader :file_id, :riiif_base
       def initialize(file_id, riiif_base: CHF::Env.lookup(:internal_riiif_url))
@@ -28,7 +28,12 @@ module CHF
       end
 
       def ping_path
-        Riiif::Engine.routes.url_helpers.info_path(file_id, locale: nil)
+        case CHF::Env.lookup(:image_server)
+        when 'riiif'
+          Riiif::Engine.routes.url_helpers.info_path(file_id, locale: nil)
+        when 'cantaloupe'
+          "/iiif/2/#{CGI.escape(file_id)}/info.json"
+        end
       end
     end
   end

--- a/lib/tasks/chf_tasks.rake
+++ b/lib/tasks/chf_tasks.rake
@@ -215,7 +215,7 @@ namespace :chf do
   end
 
   namespace :riiif do
-    desc 'Delete all files in both riiif caches. `RAILS_ENV=production bundle execrake chf:riiif:clear_caches`'
+    desc 'Delete all files in both riiif caches. `RAILS_ENV=production bundle exec rake chf:riiif:clear_caches`'
     task :clear_caches do
       # We're not doing an :environment rake dep for speed so need to load
       # our CHF::Env.
@@ -225,7 +225,7 @@ namespace :chf do
     end
 
     # Note this will not work on non-public images
-    desc 'ping riiif server to fetch all originals of publicly-visible images from fedora. `RAILS_ENV=production INTERNAL_RIIIF_URL=http://localhost bundle execrake chf:riiif:preload_originals`'
+    desc 'ping riiif server to fetch all originals of publicly-visible images from fedora. `RAILS_ENV=production INTERNAL_RIIIF_URL=http://localhost bundle exec rake chf:riiif:preload_originals`'
     task :preload_originals => :environment do
       total = FileSet.count
 

--- a/lib/tasks/chf_tasks.rake
+++ b/lib/tasks/chf_tasks.rake
@@ -225,15 +225,15 @@ namespace :chf do
     end
 
     # Note this will not work on non-public images
-    desc 'ping iiif server to fetch all originals of publicly-visible images from fedora. `RAILS_ENV=production INTERNAL_RIIIF_URL=http://localhost bundle exec rake chf:iiif:preload_originals`'
+    desc 'ping iiif server to fetch all originals of publicly-visible images from fedora. `RAILS_ENV=production IIIF_INTERNAL_URL=http://[IP]:8182/iiif/2 bundle exec rake chf:iiif:preload_originals`'
     task :preload_originals => :environment do
       total = FileSet.count
 
-      $stderr.puts "Ping'ing iiif server at `#{CHF::Env.lookup(:internal_riiif_url)}` for all #{total} FileSet original files"
+      $stderr.puts "Ping'ing iiif server at `#{CHF::Env.lookup(:iiif_internal_url)}` for all #{total} FileSet original files"
 
       progress = ProgressBar.create(total: total, format: "%t %a: |%B| %p%% %e")
 
-      iiif_base = CHF::Env.lookup(:internal_riiif_url)
+      iiif_base = CHF::Env.lookup(:iiif_internal_url)
       errors = 0
 
       # There's probably a faster way to do this, maybe from Solr instead of fedora?

--- a/lib/tasks/chf_tasks.rake
+++ b/lib/tasks/chf_tasks.rake
@@ -214,8 +214,8 @@ namespace :chf do
     end
   end
 
-  namespace :riiif do
-    desc 'Delete all files in both riiif caches. `RAILS_ENV=production bundle exec rake chf:riiif:clear_caches`'
+  namespace :iiif do
+    desc 'Delete all files in both iiif caches. `RAILS_ENV=production bundle exec rake chf:iiif:clear_caches`'
     task :clear_caches do
       # We're not doing an :environment rake dep for speed so need to load
       # our CHF::Env.
@@ -225,27 +225,27 @@ namespace :chf do
     end
 
     # Note this will not work on non-public images
-    desc 'ping riiif server to fetch all originals of publicly-visible images from fedora. `RAILS_ENV=production INTERNAL_RIIIF_URL=http://localhost bundle exec rake chf:riiif:preload_originals`'
+    desc 'ping iiif server to fetch all originals of publicly-visible images from fedora. `RAILS_ENV=production INTERNAL_RIIIF_URL=http://localhost bundle exec rake chf:iiif:preload_originals`'
     task :preload_originals => :environment do
       total = FileSet.count
 
-      $stderr.puts "Ping'ing riiif server at `#{CHF::Env.lookup(:internal_riiif_url)}` for all #{total} FileSet original files"
+      $stderr.puts "Ping'ing iiif server at `#{CHF::Env.lookup(:internal_riiif_url)}` for all #{total} FileSet original files"
 
       progress = ProgressBar.create(total: total, format: "%t %a: |%B| %p%% %e")
 
-      riiif_base = CHF::Env.lookup(:internal_riiif_url)
+      iiif_base = CHF::Env.lookup(:internal_riiif_url)
       errors = 0
 
       # There's probably a faster way to do this, maybe from Solr instead of fedora?
       # Or getting original_file_id without the extra fetch? Not sure. This is slow.
       FileSet.find_each do |fs|
         if original_file_id = fs.original_file.try(:id)
-          preloader = CHF::Utils::RiiifOriginalPreloader.new(original_file_id, riiif_base: riiif_base)
+          preloader = CHF::Utils::RiiifOriginalPreloader.new(original_file_id, riiif_base: iiif_base)
           response = preloader.ping_to_preload
 
           if response.status != 200
             errors += 1
-            progress.log "Unexpected #{response.status} response (#{errors} total) at #{riiif_base} #{preloader.ping_path}"
+            progress.log "Unexpected #{response.status} response (#{errors} total) at #{iiif_base} #{preloader.ping_path}"
           end
 
           progress.increment

--- a/spec/helpers/image_service_helper_spec.rb
+++ b/spec/helpers/image_service_helper_spec.rb
@@ -15,9 +15,15 @@ describe ImageServiceHelper do
 
     context "configured for remote box" do
       context "correct config supplied" do
-        it "provides full url" do
+        before do
           allow(CHF::Env).to receive(:lookup).with(:public_riiif_url).and_return('//example.com')
+        end
+        it "provides full riiif url" do
           expect(helper.iiif_info_url('file_id')).to eq "//example.com/image-service/file_id/info.json"
+        end
+        it "provides full cantaloupe url" do
+          allow(CHF::Env).to receive(:lookup).with(:image_server).and_return('cantaloupe')
+          expect(helper.iiif_info_url('file_id')).to eq "//example.com/iiif/2/file_id/info.json"
         end
       end
       context "bare host supplied" do

--- a/spec/helpers/image_service_helper_spec.rb
+++ b/spec/helpers/image_service_helper_spec.rb
@@ -1,25 +1,29 @@
 require 'rails_helper'
 
-describe RiiifHelper do
-  describe "#riiif_info_url" do
-    context "riiif uses localhost" do
+describe ImageServiceHelper do
+  describe "#iiif_info_url" do
+    before do
+      allow(CHF::Env).to receive(:lookup).with(:image_server).and_return('riiif')
+    end
+
+    context "using localhost" do
       it "provides relative path" do
         allow(CHF::Env).to receive(:lookup).with(:public_riiif_url).and_return(nil)
-        expect(helper.riiif_info_url('file_id')).to eq "/image-service/file_id/info.json"
+        expect(helper.iiif_info_url('file_id')).to eq "/image-service/file_id/info.json"
       end
     end
 
-    context "riiif configured for remote box" do
+    context "configured for remote box" do
       context "correct config supplied" do
         it "provides full url" do
           allow(CHF::Env).to receive(:lookup).with(:public_riiif_url).and_return('//example.com')
-          expect(helper.riiif_info_url('file_id')).to eq "//example.com/image-service/file_id/info.json"
+          expect(helper.iiif_info_url('file_id')).to eq "//example.com/image-service/file_id/info.json"
         end
       end
       context "bare host supplied" do
         it "raises" do
           allow(CHF::Env).to receive(:lookup).with(:public_riiif_url).and_return('example.com')
-          expect{ helper.riiif_info_url('file_id') }.to raise_error(RuntimeError)
+          expect{ helper.iiif_info_url('file_id') }.to raise_error(RuntimeError)
         end
       end
     end

--- a/spec/helpers/image_service_helper_spec.rb
+++ b/spec/helpers/image_service_helper_spec.rb
@@ -2,35 +2,32 @@ require 'rails_helper'
 
 describe ImageServiceHelper do
   describe "#iiif_info_url" do
-    before do
-      allow(CHF::Env).to receive(:lookup).with(:image_server).and_return('riiif')
-    end
 
-    context "using localhost" do
-      it "provides relative path" do
-        allow(CHF::Env).to receive(:lookup).with(:public_riiif_url).and_return(nil)
-        expect(helper.iiif_info_url('file_id')).to eq "/image-service/file_id/info.json"
+    context "info.json" do
+      it "works with localhost/port" do
+        allow(CHF::Env).to receive(:lookup).with(:iiif_public_url).and_return('http://localhost:3000/image-service')
+        expect(helper.iiif_info_url('file_id')).to eq "http://localhost:3000/image-service/file_id/info.json"
       end
-    end
 
-    context "configured for remote box" do
-      context "correct config supplied" do
-        before do
-          allow(CHF::Env).to receive(:lookup).with(:public_riiif_url).and_return('//example.com')
+      it "works with schemaless host" do
+        allow(CHF::Env).to receive(:lookup).with(:iiif_public_url).and_return('//localhost:3000/image-service')
+        expect(helper.iiif_info_url('file_id')).to eq "//localhost:3000/image-service/file_id/info.json"
+      end
+
+      context "with a cantaloupe host" do
+        it "works when no trailing slash" do
+          allow(CHF::Env).to receive(:lookup).with(:iiif_public_url).and_return('http://example.com:8182/iiif/2')
+          expect(helper.iiif_info_url('file_id')).to eq "http://example.com:8182/iiif/2/file_id/info.json"
         end
-        it "provides full riiif url" do
-          expect(helper.iiif_info_url('file_id')).to eq "//example.com/image-service/file_id/info.json"
-        end
-        it "provides full cantaloupe url" do
-          allow(CHF::Env).to receive(:lookup).with(:image_server).and_return('cantaloupe')
-          expect(helper.iiif_info_url('file_id')).to eq "//example.com/iiif/2/file_id/info.json"
+        it "works when yes trailing slash" do
+          allow(CHF::Env).to receive(:lookup).with(:iiif_public_url).and_return('http://example.com:8182/iiif/2/')
+          expect(helper.iiif_info_url('file_id')).to eq "http://example.com:8182/iiif/2/file_id/info.json"
         end
       end
-      context "bare host supplied" do
-        it "raises" do
-          allow(CHF::Env).to receive(:lookup).with(:public_riiif_url).and_return('example.com')
-          expect{ helper.iiif_info_url('file_id') }.to raise_error(RuntimeError)
-        end
+
+      it "raises on bare host" do
+        allow(CHF::Env).to receive(:lookup).with(:iiif_public_url).and_return('example.com')
+        expect{ helper.iiif_info_url('file_id') }.to raise_error(RuntimeError)
       end
     end
   end

--- a/spec/presenters/chf/file_set_presenter_spec.rb
+++ b/spec/presenters/chf/file_set_presenter_spec.rb
@@ -6,17 +6,17 @@ RSpec.describe CHF::FileSetPresenter do
   let(:ability) { double "Ability" }
   let(:presenter) { described_class.new(solr_document, ability) }
 
-  describe '#riiif_file_id' do
+  describe '#representative_file_id' do
     it "equals file set's original_file id" do
-      expect(presenter.riiif_file_id).to be_a String
-      expect(presenter.riiif_file_id).to eq file_set.original_file.id
+      expect(presenter.representative_file_id).to be_a String
+      expect(presenter.representative_file_id).to eq file_set.original_file.id
     end
 
     context "when it doesn't find the value in solr" do
       let(:solr_document) { SolrDocument.new(file_set.to_solr.tap { |solr_doc| solr_doc.delete('original_file_id_tesim') } ) }
       it "takes it from fedora" do
         expect(Rails.logger).to receive(:error)
-        expect(presenter.riiif_file_id).to eq file_set.original_file.id
+        expect(presenter.representative_file_id).to eq file_set.original_file.id
       end
     end
   end

--- a/spec/presenters/curation_concerns/generic_work_show_presenter_spec.rb
+++ b/spec/presenters/curation_concerns/generic_work_show_presenter_spec.rb
@@ -7,7 +7,7 @@ describe CurationConcerns::GenericWorkShowPresenter do
   let(:presenter) { described_class.new(solr_document, ability, request) }
 
 
-  describe "#riiif_file_id" do
+  describe "#representative_file_id" do
     let(:solr_document) { SolrDocument.new(work.to_solr) }
     let(:ability) { double "Ability" }
     let(:work) do
@@ -23,8 +23,8 @@ describe CurationConcerns::GenericWorkShowPresenter do
     let(:fileset2) { FactoryGirl.create(:file_set, title: ["adventure_time_2.txt"], content: StringIO.new("Mathematical!")) }
 
     it "returns representative fileset's original file id" do
-      expect(presenter.riiif_file_id).to be_a String
-      expect(presenter.riiif_file_id).to eq fileset2.original_file.id
+      expect(presenter.representative_file_id).to be_a String
+      expect(presenter.representative_file_id).to eq fileset2.original_file.id
     end
   end
 


### PR DESCRIPTION
First pass at generalizing away from the use of `riiif`. Adds switches for using cantaloupe to the path logic in the helper as well as the source cache preload task.