### PR TITLE
Generalize from `riiif` to `iiif`, allowing for use of cantaloupe or any iiif image server

### DIFF
--- a/app/helpers/image_service_helper.rb
+++ b/app/helpers/image_service_helper.rb
@@ -47,9 +47,9 @@ module ImageServiceHelper
   # any responsiveness page layout. Sends somewhat more bytes when needed at some responsive
   # sizes, but way simpler to implement; keep from asking riiiif for even more varying resizes;
   # prob good enough.
-  def riiif_image_srcset_pixel_density(riiif_file_id, base_width, format: 'jpg', quality: 'default')
+  def riiif_image_srcset_pixel_density(file_id, base_width, format: 'jpg', quality: 'default')
     [1, BigDecimal.new('1.5'), 2, 3, 4].collect do |multiplier|
-      iiif_image_url(riiif_file_id, format: "jpg", size: "#{base_width * multiplier},") + " #{multiplier}x"
+      iiif_image_url(file_id, format: "jpg", size: "#{base_width * multiplier},") + " #{multiplier}x"
     end.join(", ")
   end
 
@@ -76,15 +76,15 @@ module ImageServiceHelper
       }
     }
 
-    src_args = if member.riiif_file_id.nil?
+    src_args = if member.representative_file_id.nil?
       # if there's no image, show the default thumbnail (it gets indexed)
       {
         src:  member.thumbnail_path
       }
     elsif use_image_server
       {
-        src: iiif_image_url(member.riiif_file_id, format: "jpg", size: "#{base_width},"),
-        srcset: riiif_image_srcset_pixel_density(member.riiif_file_id, base_width)
+        src: iiif_image_url(member.representative_file_id, format: "jpg", size: "#{base_width},"),
+        srcset: riiif_image_srcset_pixel_density(member.representative_file_id, base_width)
       }
     else
       {

--- a/app/helpers/image_service_helper.rb
+++ b/app/helpers/image_service_helper.rb
@@ -1,21 +1,17 @@
 module ImageServiceHelper
 
   # Returns the IIIF info.json document, suitable as an OpenSeadragon tile source/
-  #
-  # Returns relative url unless we've defind a riiif server in config/environments/*.rb
   def iiif_info_url(image_file_id)
     path = "#{CGI.escape(image_file_id)}/info.json"
     create_iiif_url(path)
   end
 
-  # Request an image URL from the riiif server. Format, size, and quality
+  # Request an image URL from the iiif server. Format, size, and quality
   # arguments are optional, but must be formatted for IIIF api.
   # May make sense to make cover methods on top of this one
   # for specific images in specific places.
   #
   # Defaults copied from riiif defaults. https://github.com/curationexperts/riiif/blob/67ff0c49af198ba6afcf66d3db9d3d36a8694023/lib/riiif/routes.rb#L21
-  #
-  # Returns relative url unless we've defind a riiif server in config/environments/*.rb
   def iiif_image_url(image_file_id, format: 'jpg', size: "full", quality: 'default')
     path = iiif_image_path(image_file_id, size: size, format: format, quality: quality)
     create_iiif_url(path)
@@ -31,7 +27,7 @@ module ImageServiceHelper
   # any responsiveness page layout. Sends somewhat more bytes when needed at some responsive
   # sizes, but way simpler to implement; keep from asking riiiif for even more varying resizes;
   # prob good enough.
-  def riiif_image_srcset_pixel_density(file_id, base_width, format: 'jpg', quality: 'default')
+  def iiif_image_srcset_pixel_density(file_id, base_width, format: 'jpg', quality: 'default')
     [1, BigDecimal.new('1.5'), 2, 3, 4].collect do |multiplier|
       iiif_image_url(file_id, format: "jpg", size: "#{base_width * multiplier},") + " #{multiplier}x"
     end.join(", ")
@@ -39,7 +35,7 @@ module ImageServiceHelper
 
   # create an image tag for a 'member' (could be fileset or child work) thumb,
   # for use on show page. Calculates proper image tag based on lazy or not,
-  # use of riiif for images or not, and desired size. Includes proper
+  # use of iiif for images or not, and desired size. Includes proper
   # attributes for triggering viewer, analytics, etc.
   #
   # if use_image_server is false, size_key is ignored and no srcsets are generated,
@@ -68,7 +64,7 @@ module ImageServiceHelper
     elsif use_image_server
       {
         src: iiif_image_url(member.representative_file_id, format: "jpg", size: "#{base_width},"),
-        srcset: riiif_image_srcset_pixel_density(member.representative_file_id, base_width)
+        srcset: iiif_image_srcset_pixel_density(member.representative_file_id, base_width)
       }
     else
       {

--- a/app/helpers/member_helper.rb
+++ b/app/helpers/member_helper.rb
@@ -52,7 +52,7 @@ module MemberHelper
     if CHF::Env.lookup(:use_image_server_downloads)
       list_elements << dropdown_menuitem(
                         link_to("Full-size JPEG",
-                          (member ? iiif_image_url(member.riiif_file_id, format: "jpg", size: "full") : "#"),
+                          (member ? iiif_image_url(member.representative_file_id, format: "jpg", size: "full") : "#"),
                           target: "_new",
                           data: {
                             content_hook: "dl-jpeg-link",

--- a/app/helpers/member_helper.rb
+++ b/app/helpers/member_helper.rb
@@ -52,7 +52,7 @@ module MemberHelper
     if CHF::Env.lookup(:use_image_server_downloads)
       list_elements << dropdown_menuitem(
                         link_to("Full-size JPEG",
-                          (member ? riiif_image_url(member.riiif_file_id, format: "jpg", size: "full") : "#"),
+                          (member ? iiif_image_url(member.riiif_file_id, format: "jpg", size: "full") : "#"),
                           target: "_new",
                           data: {
                             content_hook: "dl-jpeg-link",

--- a/app/models/chf/env.rb
+++ b/app/models/chf/env.rb
@@ -138,6 +138,7 @@ module CHF
     define_key :riiif_identify_command
     define_key :app_role
     define_key :service_level
+    define_key :image_server
 
     define_key :use_image_server_on_show_page,
       system_env_transform: BOOLEAN_TRANSFORM,

--- a/app/models/chf/env.rb
+++ b/app/models/chf/env.rb
@@ -133,7 +133,7 @@ module CHF
     ######
 
     define_key :iiif_public_url, default: '//localhost:3000/image-service'
-    define_key :internal_riiif_url
+    define_key :iiif_internal_url
     define_key :riiif_convert_command
     define_key :riiif_identify_command
     define_key :app_role

--- a/app/models/chf/env.rb
+++ b/app/models/chf/env.rb
@@ -138,7 +138,6 @@ module CHF
     define_key :riiif_identify_command
     define_key :app_role
     define_key :service_level
-    define_key :image_server
 
     define_key :use_image_server_on_show_page,
       system_env_transform: BOOLEAN_TRANSFORM,

--- a/app/models/chf/env.rb
+++ b/app/models/chf/env.rb
@@ -132,7 +132,7 @@ module CHF
     #
     ######
 
-    define_key :public_riiif_url
+    define_key :iiif_public_url, default: '//localhost:3000/image-service'
     define_key :internal_riiif_url
     define_key :riiif_convert_command
     define_key :riiif_identify_command

--- a/app/presenters/chf/file_set_presenter.rb
+++ b/app/presenters/chf/file_set_presenter.rb
@@ -10,7 +10,7 @@ module CHF
       solr_document.visibility != Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
     end
 
-    def riiif_file_id
+    def representative_file_id
       # if it's not in solr, get it from fedora
       if original_file_id
         return original_file_id

--- a/app/presenters/curation_concerns/generic_work_show_presenter.rb
+++ b/app/presenters/curation_concerns/generic_work_show_presenter.rb
@@ -81,7 +81,7 @@ module CurationConcerns
     end
 
     def riiif_file_id
-      solr_document[ActiveFedora.index_field_mapper.solr_name('representative_original_file_id')]
+      Array.wrap(solr_document[ActiveFedora.index_field_mapper.solr_name('representative_original_file_id')]).first
     end
 
     def representative_height

--- a/app/presenters/curation_concerns/generic_work_show_presenter.rb
+++ b/app/presenters/curation_concerns/generic_work_show_presenter.rb
@@ -80,7 +80,7 @@ module CurationConcerns
       end
     end
 
-    def riiif_file_id
+    def representative_file_id
       Array.wrap(solr_document[ActiveFedora.index_field_mapper.solr_name('representative_original_file_id')]).first
     end
 

--- a/app/views/curation_concerns/base/_chf_image_viewer.html.erb
+++ b/app/views/curation_concerns/base/_chf_image_viewer.html.erb
@@ -53,10 +53,10 @@
                       member_show_url: contextual_path(member_presenter, work),
                       member_dl_original_url: main_app.download_path(member_presenter.representative_id),
                       member_dl_jpeg_url: (if CHF::Env.lookup(:use_image_server_downloads)
-                                            riiif_image_url(member_presenter.riiif_file_id, format: "jpg", size: "full")
+                                            iiif_image_url(member_presenter.riiif_file_id, format: "jpg", size: "full")
                                           end),
                       tile_source: (if CHF::Env.lookup(:use_image_server_on_viewer)
-                                      riiif_info_url(member_presenter.riiif_file_id)
+                                      iiif_info_url(member_presenter.riiif_file_id)
                                     else
                                       {"type" => "image", "url" => main_app.download_path(member_presenter.representative_id, file: "jpeg")}.to_json
                                     end),

--- a/app/views/curation_concerns/base/_chf_image_viewer.html.erb
+++ b/app/views/curation_concerns/base/_chf_image_viewer.html.erb
@@ -53,15 +53,15 @@
                       member_show_url: contextual_path(member_presenter, work),
                       member_dl_original_url: main_app.download_path(member_presenter.representative_id),
                       member_dl_jpeg_url: (if CHF::Env.lookup(:use_image_server_downloads)
-                                            iiif_image_url(member_presenter.riiif_file_id, format: "jpg", size: "full")
+                                            iiif_image_url(member_presenter.representative_file_id, format: "jpg", size: "full")
                                           end),
                       tile_source: (if CHF::Env.lookup(:use_image_server_on_viewer)
-                                      iiif_info_url(member_presenter.riiif_file_id)
+                                      iiif_info_url(member_presenter.representative_file_id)
                                     else
                                       {"type" => "image", "url" => main_app.download_path(member_presenter.representative_id, file: "jpeg")}.to_json
                                     end),
                       src: member_presenter.first(blacklight_config.view_config(document_index_view_type).thumbnail_field)
-                    } if member_presenter.riiif_file_id # don't show it in the viewer if there's no image
+                    } if member_presenter.representative_file_id # don't show it in the viewer if there's no image
                 -%>
               <%- end -%>
             <% end %>

--- a/lib/chf/utils/iiif_original_preloader.rb
+++ b/lib/chf/utils/iiif_original_preloader.rb
@@ -1,7 +1,7 @@
 module CHF
   module Utils
-    # Ping the riiif server with a HEAD info request for a given file id, to trigger
-    # caching of original asset on riiif server.
+    # Ping the iiif server with a HEAD info request for a given file id, to trigger
+    # caching of original asset on iiif server.
     #
     # You need config :iiif_internal_url set, for instance maybe IIIF_INTERNAL_URL=http://localhost:3000
     # if you really want to ping your dev server.
@@ -12,23 +12,23 @@ module CHF
     class IiifOriginalPreloader
       include ImageServiceHelper
 
-      attr_reader :file_id, :riiif_base
-      def initialize(file_id, riiif_base: CHF::Env.lookup(:iiif_internal_url))
+      attr_reader :file_id, :iiif_base
+      def initialize(file_id, iiif_base: CHF::Env.lookup(:iiif_internal_url))
         @file_id = file_id
-        @riiif_base = riiif_base
-        unless riiif_base.present?
+        @iiif_base = iiif_base
+        unless iiif_base.present?
           raise ArgumentError, "Need an :iiif_internal_url config. Can set in env with, e.g., IIIF_INTERNAL_URL=http://localhost:3000/image-service"
         end
       end
 
       # Returns Faraday::Response
       def ping_to_preload
-        conn = Faraday.new(riiif_base)
+        conn = Faraday.new(iiif_base)
         conn.head ping_path
       end
 
       def ping_path
-        path_prefix = Addressable::URI.parse(riiif_base).path # may have terminal slash, may not
+        path_prefix = Addressable::URI.parse(iiif_base).path # may have terminal slash, may not
         path_prefix << '/' if path_prefix[-1] != '/' # ensure terminal slash
         path_prefix + "#{CGI.escape(file_id)}/info.json"
       end

--- a/lib/chf/utils/iiif_original_preloader.rb
+++ b/lib/chf/utils/iiif_original_preloader.rb
@@ -28,9 +28,9 @@ module CHF
       end
 
       def ping_path
-        path_prefix = Addressable::URI.parse(iiif_base).path # may have terminal slash, may not
-        path_prefix << '/' if path_prefix[-1] != '/' # ensure terminal slash
-        path_prefix + "#{CGI.escape(file_id)}/info.json"
+        Addressable::URI.parse(iiif_base).tap do |addressable|
+          addressable.path += '/' unless addressable.path.end_with?('/')
+        end + "#{CGI.escape(file_id)}/info.json"
       end
     end
   end

--- a/lib/chf/utils/iiif_original_preloader.rb
+++ b/lib/chf/utils/iiif_original_preloader.rb
@@ -6,10 +6,10 @@ module CHF
     # You need config :iiif_internal_url set, for instance maybe IIIF_INTERNAL_URL=http://localhost:3000
     # if you really want to ping your dev server.
     #
-    #     CHF::Utils::RiiifOriginalPreloader.new(file_id).ping_to_preload
+    #     CHF::Utils::IiifOriginalPreloader.new(file_id).ping_to_preload
     #
     # NOTE: This does no auth, so will not work on non-public images
-    class RiiifOriginalPreloader
+    class IiifOriginalPreloader
       include ImageServiceHelper
 
       attr_reader :file_id, :riiif_base

--- a/lib/chf/utils/riiif_original_preloader.rb
+++ b/lib/chf/utils/riiif_original_preloader.rb
@@ -3,7 +3,7 @@ module CHF
     # Ping the riiif server with a HEAD info request for a given file id, to trigger
     # caching of original asset on riiif server.
     #
-    # You need config :internal_riiif_url set, for instance maybe INTERNAL_RIIIF_URL=http://localhost:3000
+    # You need config :iiif_internal_url set, for instance maybe IIIF_INTERNAL_URL=http://localhost:3000
     # if you really want to ping your dev server.
     #
     #     CHF::Utils::RiiifOriginalPreloader.new(file_id).ping_to_preload
@@ -13,11 +13,11 @@ module CHF
       include ImageServiceHelper
 
       attr_reader :file_id, :riiif_base
-      def initialize(file_id, riiif_base: CHF::Env.lookup(:internal_riiif_url))
+      def initialize(file_id, riiif_base: CHF::Env.lookup(:iiif_internal_url))
         @file_id = file_id
         @riiif_base = riiif_base
         unless riiif_base.present?
-          raise ArgumentError, "Need an :internal_riiif_url config. Can set in env with INTERNAL_RIIIF_URL=http://localhost:3000 or INTERNAL_RIIIF_URL=https://$internal_riiif_ip"
+          raise ArgumentError, "Need an :iiif_internal_url config. Can set in env with IIIF_INTERNAL_URL=http://localhost:3000 or IIIF_INTERNAL_URL=https://$internal_riiif_ip"
         end
       end
 

--- a/lib/chf/utils/riiif_original_preloader.rb
+++ b/lib/chf/utils/riiif_original_preloader.rb
@@ -17,7 +17,7 @@ module CHF
         @file_id = file_id
         @riiif_base = riiif_base
         unless riiif_base.present?
-          raise ArgumentError, "Need an :iiif_internal_url config. Can set in env with IIIF_INTERNAL_URL=http://localhost:3000 or IIIF_INTERNAL_URL=https://$internal_riiif_ip"
+          raise ArgumentError, "Need an :iiif_internal_url config. Can set in env with, e.g., IIIF_INTERNAL_URL=http://localhost:3000/image-service"
         end
       end
 
@@ -28,12 +28,9 @@ module CHF
       end
 
       def ping_path
-        case CHF::Env.lookup(:image_server)
-        when 'riiif'
-          Riiif::Engine.routes.url_helpers.info_path(file_id, locale: nil)
-        when 'cantaloupe'
-          "/iiif/2/#{CGI.escape(file_id)}/info.json"
-        end
+        path_prefix = Addressable::URI.parse(riiif_base).path # may have terminal slash, may not
+        path_prefix << '/' if path_prefix[-1] != '/' # ensure terminal slash
+        path_prefix + "#{CGI.escape(file_id)}/info.json"
       end
     end
   end

--- a/lib/chf/utils/riiif_original_preloader.rb
+++ b/lib/chf/utils/riiif_original_preloader.rb
@@ -10,7 +10,7 @@ module CHF
     #
     # NOTE: This does no auth, so will not work on non-public images
     class RiiifOriginalPreloader
-      include RiiifHelper
+      include ImageServiceHelper
 
       attr_reader :file_id, :riiif_base
       def initialize(file_id, riiif_base: CHF::Env.lookup(:internal_riiif_url))
@@ -28,7 +28,12 @@ module CHF
       end
 
       def ping_path
-        Riiif::Engine.routes.url_helpers.info_path(file_id, locale: nil)
+        case CHF::Env.lookup(:image_server)
+        when 'riiif'
+          Riiif::Engine.routes.url_helpers.info_path(file_id, locale: nil)
+        when 'cantaloupe'
+          "/iiif/2/#{CGI.escape(file_id)}/info.json"
+        end
       end
     end
   end

--- a/lib/tasks/chf_tasks.rake
+++ b/lib/tasks/chf_tasks.rake
@@ -240,7 +240,7 @@ namespace :chf do
       # Or getting original_file_id without the extra fetch? Not sure. This is slow.
       FileSet.find_each do |fs|
         if original_file_id = fs.original_file.try(:id)
-          preloader = CHF::Utils::IiifOriginalPreloader.new(original_file_id, riiif_base: iiif_base)
+          preloader = CHF::Utils::IiifOriginalPreloader.new(original_file_id, iiif_base: iiif_base)
           response = preloader.ping_to_preload
 
           if response.status != 200

--- a/lib/tasks/chf_tasks.rake
+++ b/lib/tasks/chf_tasks.rake
@@ -215,7 +215,7 @@ namespace :chf do
   end
 
   namespace :riiif do
-    desc 'Delete all files in both riiif caches. `RAILS_ENV=production bundle execrake chf:riiif:clear_caches`'
+    desc 'Delete all files in both riiif caches. `RAILS_ENV=production bundle exec rake chf:riiif:clear_caches`'
     task :clear_caches do
       # We're not doing an :environment rake dep for speed so need to load
       # our CHF::Env.
@@ -225,7 +225,7 @@ namespace :chf do
     end
 
     # Note this will not work on non-public images
-    desc 'ping riiif server to fetch all originals of publicly-visible images from fedora. `RAILS_ENV=production INTERNAL_RIIIF_URL=http://localhost bundle execrake chf:riiif:preload_originals`'
+    desc 'ping riiif server to fetch all originals of publicly-visible images from fedora. `RAILS_ENV=production INTERNAL_RIIIF_URL=http://localhost bundle exec rake chf:riiif:preload_originals`'
     task :preload_originals => :environment do
       total = FileSet.count
 

--- a/lib/tasks/chf_tasks.rake
+++ b/lib/tasks/chf_tasks.rake
@@ -225,15 +225,15 @@ namespace :chf do
     end
 
     # Note this will not work on non-public images
-    desc 'ping iiif server to fetch all originals of publicly-visible images from fedora. `RAILS_ENV=production INTERNAL_RIIIF_URL=http://localhost bundle exec rake chf:iiif:preload_originals`'
+    desc 'ping iiif server to fetch all originals of publicly-visible images from fedora. `RAILS_ENV=production IIIF_INTERNAL_URL=http://[IP]:8182/iiif/2 bundle exec rake chf:iiif:preload_originals`'
     task :preload_originals => :environment do
       total = FileSet.count
 
-      $stderr.puts "Ping'ing iiif server at `#{CHF::Env.lookup(:internal_riiif_url)}` for all #{total} FileSet original files"
+      $stderr.puts "Ping'ing iiif server at `#{CHF::Env.lookup(:iiif_internal_url)}` for all #{total} FileSet original files"
 
       progress = ProgressBar.create(total: total, format: "%t %a: |%B| %p%% %e")
 
-      iiif_base = CHF::Env.lookup(:internal_riiif_url)
+      iiif_base = CHF::Env.lookup(:iiif_internal_url)
       errors = 0
 
       # There's probably a faster way to do this, maybe from Solr instead of fedora?

--- a/lib/tasks/chf_tasks.rake
+++ b/lib/tasks/chf_tasks.rake
@@ -214,8 +214,8 @@ namespace :chf do
     end
   end
 
-  namespace :riiif do
-    desc 'Delete all files in both riiif caches. `RAILS_ENV=production bundle exec rake chf:riiif:clear_caches`'
+  namespace :iiif do
+    desc 'Delete all files in both iiif caches. `RAILS_ENV=production bundle exec rake chf:iiif:clear_caches`'
     task :clear_caches do
       # We're not doing an :environment rake dep for speed so need to load
       # our CHF::Env.
@@ -225,27 +225,27 @@ namespace :chf do
     end
 
     # Note this will not work on non-public images
-    desc 'ping riiif server to fetch all originals of publicly-visible images from fedora. `RAILS_ENV=production INTERNAL_RIIIF_URL=http://localhost bundle exec rake chf:riiif:preload_originals`'
+    desc 'ping iiif server to fetch all originals of publicly-visible images from fedora. `RAILS_ENV=production INTERNAL_RIIIF_URL=http://localhost bundle exec rake chf:iiif:preload_originals`'
     task :preload_originals => :environment do
       total = FileSet.count
 
-      $stderr.puts "Ping'ing riiif server at `#{CHF::Env.lookup(:internal_riiif_url)}` for all #{total} FileSet original files"
+      $stderr.puts "Ping'ing iiif server at `#{CHF::Env.lookup(:internal_riiif_url)}` for all #{total} FileSet original files"
 
       progress = ProgressBar.create(total: total, format: "%t %a: |%B| %p%% %e")
 
-      riiif_base = CHF::Env.lookup(:internal_riiif_url)
+      iiif_base = CHF::Env.lookup(:internal_riiif_url)
       errors = 0
 
       # There's probably a faster way to do this, maybe from Solr instead of fedora?
       # Or getting original_file_id without the extra fetch? Not sure. This is slow.
       FileSet.find_each do |fs|
         if original_file_id = fs.original_file.try(:id)
-          preloader = CHF::Utils::RiiifOriginalPreloader.new(original_file_id, riiif_base: riiif_base)
+          preloader = CHF::Utils::RiiifOriginalPreloader.new(original_file_id, riiif_base: iiif_base)
           response = preloader.ping_to_preload
 
           if response.status != 200
             errors += 1
-            progress.log "Unexpected #{response.status} response (#{errors} total) at #{riiif_base} #{preloader.ping_path}"
+            progress.log "Unexpected #{response.status} response (#{errors} total) at #{iiif_base} #{preloader.ping_path}"
           end
 
           progress.increment

--- a/lib/tasks/chf_tasks.rake
+++ b/lib/tasks/chf_tasks.rake
@@ -240,7 +240,7 @@ namespace :chf do
       # Or getting original_file_id without the extra fetch? Not sure. This is slow.
       FileSet.find_each do |fs|
         if original_file_id = fs.original_file.try(:id)
-          preloader = CHF::Utils::RiiifOriginalPreloader.new(original_file_id, riiif_base: iiif_base)
+          preloader = CHF::Utils::IiifOriginalPreloader.new(original_file_id, riiif_base: iiif_base)
           response = preloader.ping_to_preload
 
           if response.status != 200

--- a/lib/tasks/dev.rake
+++ b/lib/tasks/dev.rake
@@ -138,7 +138,7 @@ unless ENV['RAILS_ENV'] == "production"
       # You may want to follow up with:
       # rake chf:user:test:create[somebody@chemheritage.org,password] chf:admin:grant[somebody@chemheritage.org]
       desc "Reset db, solr, fedora, some caches, and proper setup for blank slate"
-      task :all => [:solr, :fedora, :derivatives, :redis, "db:reset", "chf:riiif:clear_caches"]  do
+      task :all => [:solr, :fedora, :derivatives, :redis, "db:reset", "chf:iiif:clear_caches"]  do
         Rake::Task['curation_concerns:workflow:load'].invoke
         Rake::Task['sufia:default_admin_set:create'].invoke
       end

--- a/spec/helpers/image_service_helper_spec.rb
+++ b/spec/helpers/image_service_helper_spec.rb
@@ -15,9 +15,15 @@ describe ImageServiceHelper do
 
     context "configured for remote box" do
       context "correct config supplied" do
-        it "provides full url" do
+        before do
           allow(CHF::Env).to receive(:lookup).with(:public_riiif_url).and_return('//example.com')
+        end
+        it "provides full riiif url" do
           expect(helper.iiif_info_url('file_id')).to eq "//example.com/image-service/file_id/info.json"
+        end
+        it "provides full cantaloupe url" do
+          allow(CHF::Env).to receive(:lookup).with(:image_server).and_return('cantaloupe')
+          expect(helper.iiif_info_url('file_id')).to eq "//example.com/iiif/2/file_id/info.json"
         end
       end
       context "bare host supplied" do

--- a/spec/helpers/image_service_helper_spec.rb
+++ b/spec/helpers/image_service_helper_spec.rb
@@ -2,10 +2,12 @@ require 'rails_helper'
 
 describe ImageServiceHelper do
   describe "#iiif_info_url" do
+    before do
+      allow(CHF::Env).to receive(:lookup).with(:iiif_public_url).and_return('http://localhost:3000/image-service')
+    end
 
     context "info.json" do
       it "works with localhost/port" do
-        allow(CHF::Env).to receive(:lookup).with(:iiif_public_url).and_return('http://localhost:3000/image-service')
         expect(helper.iiif_info_url('file_id')).to eq "http://localhost:3000/image-service/file_id/info.json"
       end
 
@@ -14,13 +16,18 @@ describe ImageServiceHelper do
         expect(helper.iiif_info_url('file_id')).to eq "//localhost:3000/image-service/file_id/info.json"
       end
 
+      it "escapes id" do
+        expect(helper.iiif_info_url('path/file_id')).to eq "http://localhost:3000/image-service/#{CGI.escape 'path/file_id'}/info.json"
+      end
+
       context "with a cantaloupe host" do
-        it "works when no trailing slash" do
+        before do
           allow(CHF::Env).to receive(:lookup).with(:iiif_public_url).and_return('http://example.com:8182/iiif/2')
+        end
+        it "works when no trailing slash" do
           expect(helper.iiif_info_url('file_id')).to eq "http://example.com:8182/iiif/2/file_id/info.json"
         end
         it "works when yes trailing slash" do
-          allow(CHF::Env).to receive(:lookup).with(:iiif_public_url).and_return('http://example.com:8182/iiif/2/')
           expect(helper.iiif_info_url('file_id')).to eq "http://example.com:8182/iiif/2/file_id/info.json"
         end
       end
@@ -28,6 +35,19 @@ describe ImageServiceHelper do
       it "raises on bare host" do
         allow(CHF::Env).to receive(:lookup).with(:iiif_public_url).and_return('example.com')
         expect{ helper.iiif_info_url('file_id') }.to raise_error(RuntimeError)
+      end
+    end
+  end
+
+  describe "#iiif_image_url" do
+    describe "with base url with path" do
+      let(:file_id) { "test_file_id/something" }
+      before do
+        allow(CHF::Env).to receive(:lookup).with(:iiif_public_url).and_return('http://localhost:3000/image-service')
+      end
+
+      it "joins properly" do
+        expect( helper.iiif_image_url(file_id)).to eq("http://localhost:3000/image-service/test_file_id%2Fsomething/full/full/0/default.jpg")
       end
     end
   end

--- a/spec/helpers/image_service_helper_spec.rb
+++ b/spec/helpers/image_service_helper_spec.rb
@@ -1,25 +1,29 @@
 require 'rails_helper'
 
-describe RiiifHelper do
-  describe "#riiif_info_url" do
-    context "riiif uses localhost" do
+describe ImageServiceHelper do
+  describe "#iiif_info_url" do
+    before do
+      allow(CHF::Env).to receive(:lookup).with(:image_server).and_return('riiif')
+    end
+
+    context "using localhost" do
       it "provides relative path" do
         allow(CHF::Env).to receive(:lookup).with(:public_riiif_url).and_return(nil)
-        expect(helper.riiif_info_url('file_id')).to eq "/image-service/file_id/info.json"
+        expect(helper.iiif_info_url('file_id')).to eq "/image-service/file_id/info.json"
       end
     end
 
-    context "riiif configured for remote box" do
+    context "configured for remote box" do
       context "correct config supplied" do
         it "provides full url" do
           allow(CHF::Env).to receive(:lookup).with(:public_riiif_url).and_return('//example.com')
-          expect(helper.riiif_info_url('file_id')).to eq "//example.com/image-service/file_id/info.json"
+          expect(helper.iiif_info_url('file_id')).to eq "//example.com/image-service/file_id/info.json"
         end
       end
       context "bare host supplied" do
         it "raises" do
           allow(CHF::Env).to receive(:lookup).with(:public_riiif_url).and_return('example.com')
-          expect{ helper.riiif_info_url('file_id') }.to raise_error(RuntimeError)
+          expect{ helper.iiif_info_url('file_id') }.to raise_error(RuntimeError)
         end
       end
     end

--- a/spec/helpers/image_service_helper_spec.rb
+++ b/spec/helpers/image_service_helper_spec.rb
@@ -2,35 +2,32 @@ require 'rails_helper'
 
 describe ImageServiceHelper do
   describe "#iiif_info_url" do
-    before do
-      allow(CHF::Env).to receive(:lookup).with(:image_server).and_return('riiif')
-    end
 
-    context "using localhost" do
-      it "provides relative path" do
-        allow(CHF::Env).to receive(:lookup).with(:public_riiif_url).and_return(nil)
-        expect(helper.iiif_info_url('file_id')).to eq "/image-service/file_id/info.json"
+    context "info.json" do
+      it "works with localhost/port" do
+        allow(CHF::Env).to receive(:lookup).with(:iiif_public_url).and_return('http://localhost:3000/image-service')
+        expect(helper.iiif_info_url('file_id')).to eq "http://localhost:3000/image-service/file_id/info.json"
       end
-    end
 
-    context "configured for remote box" do
-      context "correct config supplied" do
-        before do
-          allow(CHF::Env).to receive(:lookup).with(:public_riiif_url).and_return('//example.com')
+      it "works with schemaless host" do
+        allow(CHF::Env).to receive(:lookup).with(:iiif_public_url).and_return('//localhost:3000/image-service')
+        expect(helper.iiif_info_url('file_id')).to eq "//localhost:3000/image-service/file_id/info.json"
+      end
+
+      context "with a cantaloupe host" do
+        it "works when no trailing slash" do
+          allow(CHF::Env).to receive(:lookup).with(:iiif_public_url).and_return('http://example.com:8182/iiif/2')
+          expect(helper.iiif_info_url('file_id')).to eq "http://example.com:8182/iiif/2/file_id/info.json"
         end
-        it "provides full riiif url" do
-          expect(helper.iiif_info_url('file_id')).to eq "//example.com/image-service/file_id/info.json"
-        end
-        it "provides full cantaloupe url" do
-          allow(CHF::Env).to receive(:lookup).with(:image_server).and_return('cantaloupe')
-          expect(helper.iiif_info_url('file_id')).to eq "//example.com/iiif/2/file_id/info.json"
+        it "works when yes trailing slash" do
+          allow(CHF::Env).to receive(:lookup).with(:iiif_public_url).and_return('http://example.com:8182/iiif/2/')
+          expect(helper.iiif_info_url('file_id')).to eq "http://example.com:8182/iiif/2/file_id/info.json"
         end
       end
-      context "bare host supplied" do
-        it "raises" do
-          allow(CHF::Env).to receive(:lookup).with(:public_riiif_url).and_return('example.com')
-          expect{ helper.iiif_info_url('file_id') }.to raise_error(RuntimeError)
-        end
+
+      it "raises on bare host" do
+        allow(CHF::Env).to receive(:lookup).with(:iiif_public_url).and_return('example.com')
+        expect{ helper.iiif_info_url('file_id') }.to raise_error(RuntimeError)
       end
     end
   end

--- a/spec/presenters/chf/file_set_presenter_spec.rb
+++ b/spec/presenters/chf/file_set_presenter_spec.rb
@@ -6,17 +6,17 @@ RSpec.describe CHF::FileSetPresenter do
   let(:ability) { double "Ability" }
   let(:presenter) { described_class.new(solr_document, ability) }
 
-  describe '#riiif_file_id' do
+  describe '#representative_file_id' do
     it "equals file set's original_file id" do
-      expect(presenter.riiif_file_id).to be_a String
-      expect(presenter.riiif_file_id).to eq file_set.original_file.id
+      expect(presenter.representative_file_id).to be_a String
+      expect(presenter.representative_file_id).to eq file_set.original_file.id
     end
 
     context "when it doesn't find the value in solr" do
       let(:solr_document) { SolrDocument.new(file_set.to_solr.tap { |solr_doc| solr_doc.delete('original_file_id_tesim') } ) }
       it "takes it from fedora" do
         expect(Rails.logger).to receive(:error)
-        expect(presenter.riiif_file_id).to eq file_set.original_file.id
+        expect(presenter.representative_file_id).to eq file_set.original_file.id
       end
     end
   end

--- a/spec/presenters/curation_concerns/generic_work_show_presenter_spec.rb
+++ b/spec/presenters/curation_concerns/generic_work_show_presenter_spec.rb
@@ -7,7 +7,7 @@ describe CurationConcerns::GenericWorkShowPresenter do
   let(:presenter) { described_class.new(solr_document, ability, request) }
 
 
-  describe "#riiif_file_id" do
+  describe "#representative_file_id" do
     let(:solr_document) { SolrDocument.new(work.to_solr) }
     let(:ability) { double "Ability" }
     let(:work) do
@@ -23,8 +23,8 @@ describe CurationConcerns::GenericWorkShowPresenter do
     let(:fileset2) { FactoryGirl.create(:file_set, title: ["adventure_time_2.txt"], content: StringIO.new("Mathematical!")) }
 
     it "returns representative fileset's original file id" do
-      expect(presenter.riiif_file_id).to be_a String
-      expect(presenter.riiif_file_id).to eq fileset2.original_file.id
+      expect(presenter.representative_file_id).to be_a String
+      expect(presenter.representative_file_id).to eq fileset2.original_file.id
     end
   end
 


### PR DESCRIPTION
Show page verified working with riiif, cantaloupe, and neither (derivative thumbnails).
iiif preload verified working with riiif and cantaloupe.

Configuration now must be provided for a full url, including base path, e.g. (cantaloupe local_env.yml example) `iiif_public_url: //images.digital.chemheritage.org:8080/iiif/2` or (riiif ENV example) `IIIF_INTERNAL_URL=http://localhost:3000/image-service`

@jrochkind I believe this addresses all your notes from #739 except https://github.com/chemheritage/chf-sufia/pull/739/files/baf22ad92add4758e175220dce9adf766b7fe923#r130358339 since I couldn't think of a case where we would be using those. But if you think it's important I can do it or you can change it!