### PR TITLE
Fix viewer freeze on close with cantaloupe

### DIFF
--- a/app/assets/javascripts/chf_image_viewer.js
+++ b/app/assets/javascripts/chf_image_viewer.js
@@ -88,6 +88,7 @@ ChfImageViewer.prototype.hide = function() {
   if (OpenSeadragon.isFullScreen()) {
     OpenSeadragon.exitFullScreen();
   }
+  this.viewer.close();
   $(this.modal).modal("hide");
   this.removeLocationUrl();
   this.restoreFocus();

--- a/app/assets/javascripts/chf_image_viewer.js
+++ b/app/assets/javascripts/chf_image_viewer.js
@@ -130,6 +130,8 @@ ChfImageViewer.prototype.selectThumb = function(thumbElement) {
   var downloadJpegUrl = thumbElement.getAttribute('data-member-dl-jpeg-url');
   var tileSource = thumbElement.getAttribute('data-tile-source');
 
+  this.viewer.close();
+
   this.addLoading();
 
   this.viewer.open(tileSource);


### PR DESCRIPTION
OSD continues to call its update method when the modal is hidden. Closing it will keep it from running when out of site.

Still unclear why this only causes problems with cantaloupe, and for only some images. Here is where I stopped with my debug efforts:

Upload a file which was causing us problems, e.g. http://54.174.106.16/concern/generic_works/kp78gg445

with a breakpoint at this line you can open the viewer, then hit 'play', then zoom in then close the viewer, and drop into the browser's debugger at the right time
https://github.com/cbeer/openseadragon-rails/blob/master/vendor/assets/javascripts/openseadragon/openseadragon.js#L10126
Then I set other breakpoints because it takes a lot of stepping to get to a problem area.
  
For example, you can set a breakpoint at
https://github.com/cbeer/openseadragon-rails/blob/master/vendor/assets/javascripts/openseadragon/openseadragon.js#L20513
to start seeing infinities pop up.
  
x and y are getting set to Infinity when level is 0
https://github.com/openseadragon/openseadragon/blob/fd502dbdabf42b5cd6619ba97accbccab735eec3/src/tilesource.js#L355-L356
  
because _tileHeight is 0.
  
I guess next step would be to figure out why tileHeight is 0, if it's not supposed to be?
Or whether these stuff should be run for level 0 at all?