### PR TITLE
Index representative_checksum too, for fingerprinted URLs

### DIFF
--- a/app/indexers/chf/file_set_indexer.rb
+++ b/app/indexers/chf/file_set_indexer.rb
@@ -4,6 +4,7 @@ module CHF
       super.tap do |doc|
         if object.original_file
           doc[ActiveFedora.index_field_mapper.solr_name('original_file_id')] = object.original_file.id
+          doc[ActiveFedora.index_field_mapper.solr_name('original_file_checksum')] = object.original_file.checksum.value
         end
       end
     end

--- a/app/indexers/chf/generic_work_indexer.rb
+++ b/app/indexers/chf/generic_work_indexer.rb
@@ -37,6 +37,7 @@ module CHF
           doc[ActiveFedora.index_field_mapper.solr_name('representative_width', type: :integer)] = representative.width.first if representative.width.present?
           doc[ActiveFedora.index_field_mapper.solr_name('representative_height', type: :integer)] = representative.height.first if representative.height.present?
           doc[ActiveFedora.index_field_mapper.solr_name('representative_original_file_id')] = representative.original_file.id if representative.original_file
+          doc[ActiveFedora.index_field_mapper.solr_name('representative_checksum')] = representative.original_file.checksum.value if representative.original_file
         end
       end
     end

--- a/app/models/generic_work.rb
+++ b/app/models/generic_work.rb
@@ -25,7 +25,7 @@ class GenericWork < ActiveFedora::Base
   # but it seems to work not missing anything.
   #
   # This code goes with custom code in indexer to index representative_width,
-  # representative_height, and representative_original_file_id.
+  # representative_height, representative_original_file_id, and representative_checksum
   def update_index(*args)
     super.tap do
       if self.changes.keys.include?("representative_id") ||

--- a/app/presenters/chf/file_set_presenter.rb
+++ b/app/presenters/chf/file_set_presenter.rb
@@ -2,7 +2,7 @@ module CHF
   # Add some things we can use for our custom UI
   class FileSetPresenter < Sufia::FileSetPresenter
 
-    delegate :original_file_id, to: :solr_document
+    delegate :original_file_id, :original_checksum, to: :solr_document
 
     # Consistent API with GenericWorkShowPresenter, on show pages we often
     # only show permissoin badge if not open access.
@@ -18,6 +18,10 @@ module CHF
         Rails.logger.error "ERROR: Could not find FileSet #{id} original_file_id in Solr. You may need to reindex."
         return FileSet.find(id).original_file.id
       end
+    end
+
+    def representative_checksum
+      original_checksum
     end
 
     def representative_height

--- a/app/presenters/chf/file_set_presenter.rb
+++ b/app/presenters/chf/file_set_presenter.rb
@@ -2,7 +2,7 @@ module CHF
   # Add some things we can use for our custom UI
   class FileSetPresenter < Sufia::FileSetPresenter
 
-    delegate :original_file_id, :original_checksum, to: :solr_document
+    delegate :original_file_id, to: :solr_document
 
     # Consistent API with GenericWorkShowPresenter, on show pages we often
     # only show permissoin badge if not open access.
@@ -21,8 +21,7 @@ module CHF
     end
 
     def representative_checksum
-      # somehow coming back as array instead of single element, only sometimes
-      Array(original_checksum).first
+      Array(solr_document[Solrizer.solr_name("original_file_checksum")]).first
     end
 
     def representative_height

--- a/app/presenters/chf/file_set_presenter.rb
+++ b/app/presenters/chf/file_set_presenter.rb
@@ -21,7 +21,8 @@ module CHF
     end
 
     def representative_checksum
-      original_checksum
+      # somehow coming back as array instead of single element, only sometimes
+      Array(original_checksum).first
     end
 
     def representative_height

--- a/app/presenters/curation_concerns/generic_work_show_presenter.rb
+++ b/app/presenters/curation_concerns/generic_work_show_presenter.rb
@@ -84,6 +84,10 @@ module CurationConcerns
       Array.wrap(solr_document[ActiveFedora.index_field_mapper.solr_name('representative_original_file_id')]).first
     end
 
+    def representative_checksum
+      Array.wrap(solr_document[ActiveFedora.index_field_mapper.solr_name('representative_checksum')]).first
+    end
+
     def representative_height
       solr_document[ActiveFedora.index_field_mapper.solr_name('representative_height', type: :integer)]
     end

--- a/spec/indexers/chf/file_set_indexer_spec.rb
+++ b/spec/indexers/chf/file_set_indexer_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe CHF::FileSetIndexer do
   let(:mock_file) {
       mock_model('MockFile',
                  id: 'totally_a_file_id',
+                 checksum: OpenStruct.new(value: 'totally_a_checksum'),
                  # test fails if we don't include all these:
                  mime_type:         'text/plain',
                  format_label:      [],

--- a/spec/indexers/chf/generic_work_indexer_spec.rb
+++ b/spec/indexers/chf/generic_work_indexer_spec.rb
@@ -57,6 +57,7 @@ RSpec.describe CHF::GenericWorkIndexer do
     let(:width_field) { Solrizer.solr_name("representative_width", type: :integer) }
     let(:height_field) { Solrizer.solr_name("representative_height", type: :integer) }
     let(:file_id_field) { Solrizer.solr_name("representative_original_file_id") }
+    let(:file_checksum_field) { Solrizer.solr_name("representative_checksum")}
 
     describe "standard work with representative fileset" do
       let(:work) do
@@ -67,6 +68,7 @@ RSpec.describe CHF::GenericWorkIndexer do
       end
       it "indexes representative fields" do
         expect(solr_document[file_id_field]).to eq(work.representative.original_file.id)
+        expect(solr_document[file_checksum_field]).to eq(work.representative.original_file.checksum.value)
         expect(solr_document[width_field]).to eq(width)
         expect(solr_document[height_field]).to eq(height)
       end


### PR DESCRIPTION
Using the checksum in the URL for assets is nice, becuase it menas you can make
them infinitely cacheable (For instance for browsers), even if the image behind
a file_id changes (versions?).  I am doing this for DZI experiment, but it's
potentially applicable to all our image sources. 

But that means it's gotta be indexed, so you have it to generate the URLs
at display time. 

Yes, this apparently requires touching five different files!