### PR TITLE
Allow physical container to be emptied; add feature spec to prevent regression

### DIFF
--- a/app/forms/concerns/work_form_behavior.rb
+++ b/app/forms/concerns/work_form_behavior.rb
@@ -171,14 +171,15 @@ module WorkFormBehavior
       def self.encode_physical_container(params, clean_params)
         result = []
         CHF::Utils::ParseFields.physical_container_fields.values.each do |k|
-          # check for some data
+          # When saving permissions / version changes, these params aren't in the form.
+          #   return unchanged params at first nil to avoid losing data.
+          return clean_params if params[k].nil?
+          # But we do want to be able to blank it out otherwise, so check for empty string.
           if params[k].present?
             result << "#{CHF::Utils::ParseFields.physical_container_fields_reverse[k]}#{params[k]}"
           end
         end
-        unless result.empty?
-          clean_params['physical_container'] = result.join('|')
-        end
+        clean_params['physical_container'] = result.join('|')
         clean_params
       end
 
@@ -199,7 +200,6 @@ module WorkFormBehavior
         end
         clean_params
       end
-
 
   end
 end

--- a/spec/controllers/curation_concerns/generic_works_controller_spec.rb
+++ b/spec/controllers/curation_concerns/generic_works_controller_spec.rb
@@ -462,6 +462,8 @@ describe CurationConcerns::GenericWorksController do
         patch :update, id: work, generic_work: {
           box: '2',
           folder: '3',
+          volume: '',
+          part: '',
           page: '14',
         }
 

--- a/spec/features/generic_work_form_spec.rb
+++ b/spec/features/generic_work_form_spec.rb
@@ -56,6 +56,14 @@ RSpec.feature "Editing metadata of generic work" do
       expect(page.find('li.artist').text).to eq('Zeldog')
     end
 
+    scenario "allows deletion of physical_container", js: true do
+      fill_in 'generic_work_volume', with: ''
+      fill_in 'generic_work_part', with: ''
+      fill_in 'generic_work_page', with: ''
+      click_button 'Save'
+      expect(page).not_to have_selector('li.physical_container')
+    end
+
     # this test passing erroneously
     xscenario "saves a new external id field", js: true  do
       visit "/concern/generic_works/#{@work.id}/edit"

--- a/spec/features/generic_work_form_spec.rb
+++ b/spec/features/generic_work_form_spec.rb
@@ -45,15 +45,15 @@ RSpec.feature "Editing metadata of generic work" do
       page.assert_selector('input.physical_container', :count => 5)
     end
 
-    xscenario "saves a new maker field", js: true  do
+    scenario "saves a new maker field", js: true  do
       # TODO: test one or more nested fields'
-      expect(page).to have_text 'Maker'
+      expect(page).to have_text 'Creator'
       expect(page).to have_no_field('generic_work_photographer')
       select 'Artist', from: 'generic_work_maker'
       # change below to look more like the "fills in correctly" tests.
       fill_in 'generic_work_artist', with: 'Zeldog'
-      click_button 'Save Descriptions'
-      expect(page.find('div.generic_work_maker').first('input').value).to eq('Zeldog')
+      click_button 'Save'
+      expect(page.find('li.artist').text).to eq('Zeldog')
     end
 
     # this test passing erroneously


### PR DESCRIPTION
Looks like whatever was preventing me from doing feature specs involving form submission is resolved. I must have made a config change somewhere along the way that fixed this!

This PR includes another feature spec fix which I did first just to see whether they were working.