### PR TITLE
Set default search fields to the same as 'all fields', fixes #673

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -86,7 +86,7 @@ class CatalogController < ApplicationController
     config.default_solr_params = {
       qt: "search",
       rows: 10,
-      qf: "title_tesim name_tesim"
+      qf: "#{chf_search_fields.join(" ")} file_format_tesim all_text_timv",
     }
 
     # solr field configuration for document/show views


### PR DESCRIPTION
@jrochkind any reason why our default search fields shouldn't be the same as our 'all fields' keyword search?