### PR TITLE
Charts genre step 1

### DIFF
--- a/app/forms/batch_edit_form.rb
+++ b/app/forms/batch_edit_form.rb
@@ -66,6 +66,14 @@ class BatchEditForm < Sufia::Forms::BatchEditForm
     # due to a bug released in sufia 7.3:
     # https://github.com/projecthydra-labs/hyrax/issues/652
     clean_params['permissions_attributes'] = params['permissions_attributes'] if params['permissions_attributes']
+
+    # temporary while both terms are in the drop-down due to changing data
+    old_value = "Diagrams"
+    new_value = "Charts, diagrams, etc"
+    if clean_params[:genre_string] && clean_params[:genre_string].include?(old_value)
+      clean_params[:genre_string] = clean_params[:genre_string].map { |s| s == old_value ? new_value : s }
+    end
+
     clean_params
   end
 

--- a/app/forms/concerns/work_form_behavior.rb
+++ b/app/forms/concerns/work_form_behavior.rb
@@ -86,6 +86,13 @@ module WorkFormBehavior
         end
       end
 
+      # temporary while both terms are in the drop-down due to changing data
+      old_value = "Diagrams"
+      new_value = "Charts, diagrams, etc"
+      if clean_params[:genre_string] && clean_params[:genre_string].include?(old_value)
+        clean_params[:genre_string] = clean_params[:genre_string].map { |s| s == old_value ? new_value : s }
+      end
+
       clean_params
     end
   end

--- a/config/application.rb
+++ b/config/application.rb
@@ -118,6 +118,7 @@ module Chufia
       'Artifacts',
       'Business correspondence',
       'Catalogs',
+      'Charts, diagrams, etc',
       'Chemistry sets',
       'Clothing & dress',
       'Diagrams',

--- a/lib/chf/data_fixes/genre_charts.rb
+++ b/lib/chf/data_fixes/genre_charts.rb
@@ -1,0 +1,25 @@
+module CHF
+  module DataFixes
+    class GenreCharts
+      OLD_VALUE = "Diagrams"
+      NEW_VALUE = "Charts, diagrams, etc"
+
+      attr_reader :work
+
+      def initialize(work)
+        @work = work
+      end
+
+      # possibly makes changes to work (without saving), returns true
+      # if changes were made, so caller can do expensive save.
+      def change
+        if work.genre_string.include? OLD_VALUE
+          # << doesn't work on this property in all versions
+          work.genre_string = work.genre_string.map { |s| s == OLD_VALUE ? NEW_VALUE : s }
+          return true
+        end
+        return false
+      end
+    end
+  end
+end

--- a/lib/tasks/data_fixes.rake
+++ b/lib/tasks/data_fixes.rake
@@ -26,6 +26,13 @@ namespace :chf do
       end
     end
 
+    desc "'Diagrams' to 'Charts, diagrams, etc' in genre"
+    task :genre_charts => :environment do
+      CHF::DataFixes::Util.update_works do |w|
+        CHF::DataFixes::GenreCharts.new(w).change
+      end
+    end
+
     desc "Fix Work dates to be Dates"
     task :fix_work_dates => :environment do
       CHF::DataFixes::Util.update_works do |w|


### PR DESCRIPTION
Pending testing on staging.

This PR:
- Adds the new option to the form.
- Adds the migration task.
- Adds a data filter to form processing that catches any attempts to save the old term and converts it into the new term. This will keep new edits from creeping in after the task has run but before the old option has been removed from the form. This code is intended to be temporary, removed in the follow-on PR. Thus it is isolated in its own commit.

The removal of the old option is in a follow-on PR

Refs #562
