### PR TITLE
Move fixity cron back to app box

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -7,7 +7,10 @@ every 1.month, roles: [:app] do
   rake "chf:metadata_report"
 end
 
-every 1.day, :at => '2:30 am', roles: [:jobs] do
+# if we decide to move this to the jobs box, wse'll need to
+# update the postgres configuration to accept non-localhost connections
+# will require brief downtime of staff functionality
+every 1.day, :at => '2:30 am', roles: [:app] do
   rake "chf:fixity_checks"
 end
 


### PR DESCRIPTION
The rails postgres wasn't configured to allow connections outside of localhost. We probably should change that; definitely will need to if we want to move fixity cron onto jobs box. Changing that configuration will require scheduled downtime for the staff side (will there be an impact for non-logged-in users?)

In the meantime move this cron back to the app box.