### PR TITLE
Improvements to lazyloading images and aspectratios

### DIFF
--- a/app/assets/stylesheets/local/chf_image_viewer.scss
+++ b/app/assets/stylesheets/local/chf_image_viewer.scss
@@ -295,6 +295,7 @@ $chf_image_viewer_thumb_width: 60px; // Needs to match MemberHelper::VIEWER_THUM
       &.lazyload, &.lazyloading, &.lazyload {
         background: #AAA asset-url('spinner.svg') no-repeat center;
         background-size: 34px 34px;
+        background-clip: content-box;
       }
     }
   }

--- a/app/assets/stylesheets/local/chf_image_viewer.scss
+++ b/app/assets/stylesheets/local/chf_image_viewer.scss
@@ -20,6 +20,8 @@
     contents and have CSS properties relevant to that too.
 */
 
+$chf_image_viewer_thumb_width: 60px;
+
 // Override some bootstrap modal stuff to give us a full-viewport modal
 #chf-image-viewer-modal {
   .modal-dialog {
@@ -277,8 +279,8 @@
     max-height: 100%; // IE 11 needs this, although others don't, i dunno.
 
     .viewer-thumb-img {
-      height: 80px;
-      max-width: 240px;
+      max-height: 80px;
+      width: $chf_image_viewer_thumb_width;
 
       cursor: pointer;
 
@@ -319,14 +321,11 @@
       overflow-y: auto;
       overflow-x: hidden;
       // need to leave enough room for scroll-bar on browsers that count that inside
-      width: calc(60px * 2 + 7px * 3 + 1em);
+      width: calc(#{$chf_image_viewer_thumb_width} * 2 + 7px * 3 + 1em);
       flex-shrink: 0;
 
       .viewer-thumb-img {
-        height: auto;
-        max-width: none;
-        width: 60px;
-        max-height: 120px;
+        max-height: $chf_image_viewer_thumb_width * 2;
       }
     }
     .viewer-download {

--- a/app/assets/stylesheets/local/chf_image_viewer.scss
+++ b/app/assets/stylesheets/local/chf_image_viewer.scss
@@ -20,7 +20,7 @@
     contents and have CSS properties relevant to that too.
 */
 
-$chf_image_viewer_thumb_width: 60px;
+$chf_image_viewer_thumb_width: 60px; // Needs to match MemberHelper::VIEWER_THUMB_WIDTH
 
 // Override some bootstrap modal stuff to give us a full-viewport modal
 #chf-image-viewer-modal {

--- a/app/assets/stylesheets/local/chf_image_viewer.scss
+++ b/app/assets/stylesheets/local/chf_image_viewer.scss
@@ -279,6 +279,7 @@ $chf_image_viewer_thumb_width: 60px; // Needs to match MemberHelper::VIEWER_THUM
     max-height: 100%; // IE 11 needs this, although others don't, i dunno.
 
     .viewer-thumb-img {
+      display: inline-block; // makes FF respect width on unloaded image, not sure why needed
       max-height: 80px;
       width: $chf_image_viewer_thumb_width;
 

--- a/app/assets/stylesheets/local/show.scss
+++ b/app/assets/stylesheets/local/show.scss
@@ -91,6 +91,8 @@
     cursor: pointer;
 
     .show-page-image-image {
+      // not sure why inline-block seems now neccesary to get JS aspectratio setting to work
+      display: inline-block;
       width: 100%;
       // sanity max-height to keep keep crazy long aspect ratio images from
       // totally ruining page. Very difficult to get this right based on

--- a/app/helpers/member_helper.rb
+++ b/app/helpers/member_helper.rb
@@ -116,4 +116,19 @@ module MemberHelper
                 role: "menu",
                 :'aria-labelledby' => labelled_by)
   end
+
+
+  VIEWER_THUMB_WIDTH = 60
+  # Calculate height matching width for a aspect ratio of member_presenter.
+  # default target_width should match CSS, in chf_image_viewer.scss, .viewer-thumb-img `width`
+  def member_proportional_height(member_presenter, target_width: VIEWER_THUMB_WIDTH)
+    original_width = member_presenter.representative_width.try(:to_i)
+    original_height = member_presenter.representative_height.try(:to_i)
+
+    if original_width && original_width > 0 && original_height && original_height > 0
+      target_width * original_height / original_width
+    end
+  end
+
+
 end

--- a/app/views/curation_concerns/base/_chf_image_viewer.html.erb
+++ b/app/views/curation_concerns/base/_chf_image_viewer.html.erb
@@ -41,11 +41,11 @@
               <% work.viewable_member_presenters.each_with_index do |member_presenter, i| -%>
                 <%= tag "img",
                     class: "lazyload viewer-thumb-img",
+                    height: member_proportional_height(member_presenter),
                     alt: "",
                     tabindex: "0",
                     role: "button",
                     data: {
-                      aspectratio: "#{member_presenter.representative_width}/#{member_presenter.representative_height}", # used for lazysizes-aspectratio
                       trigger: 'change-viewer-source',
                       index: i + 1,
                       title: member_presenter.link_name,


### PR DESCRIPTION
See individual commits. Includes removing use of js lazy aspectratios
in viewer thumbs, for hard-coded ones instead. 

I believe lazyloading with aspectratios should be working well here,
and no longer will a direct to /viewer link on a many-membered work
freeze up the browser for a while. 

One thing we might want to do that I have NOT done yet is replace
the animated spinner with a static wait/progress icon of some kind. 
I think so many instances of that animated spinner on a page are putting
stress on CPU. 

Ref #792 #793