### PR TITLE
index work representative_file_set_id

### DIFF
--- a/app/indexers/chf/generic_work_indexer.rb
+++ b/app/indexers/chf/generic_work_indexer.rb
@@ -37,6 +37,7 @@ module CHF
           doc[ActiveFedora.index_field_mapper.solr_name('representative_width', type: :integer)] = representative.width.first if representative.width.present?
           doc[ActiveFedora.index_field_mapper.solr_name('representative_height', type: :integer)] = representative.height.first if representative.height.present?
           doc[ActiveFedora.index_field_mapper.solr_name('representative_original_file_id')] = representative.original_file.id if representative.original_file
+          doc[ActiveFedora.index_field_mapper.solr_name('representative_file_set_id')] = representative.id if representative.original_file
           doc[ActiveFedora.index_field_mapper.solr_name('representative_checksum')] = representative.original_file.checksum.value if representative.original_file
         end
       end


### PR DESCRIPTION
Turns out we actually need this to properly display thumbs for a work even with
multiple levels of nesting. didn't run into the bug in production cause we don't
have those. But in results refresh, we run into it attmepting to make thumbs.

This commit just establishes the indexing, nothing uses it. Index only commit
to master, so we can reindex before we have anything that uses it.

Requires reindex after deploy.