### PR TITLE
S3 permissions

### DIFF
--- a/lib/tasks/chf_tasks.rake
+++ b/lib/tasks/chf_tasks.rake
@@ -225,6 +225,18 @@ namespace :chf do
     desc "set bucket configuration"
     task :configure_bucket => :environment do
       client = CHF::CreateDziService.s3_client!
+      dzi_policy = {
+          "Version":"2012-10-17",
+          "Statement":[
+          {
+            "Sid":"AddPerm",
+            "Effect":"Allow",
+            "Principal": "*",
+            "Action":["s3:GetObject"],
+            "Resource":["arn:aws:s3:::#{CHF::CreateDziService.bucket_name}/*"]
+          }
+        ]
+      }.to_json
 
       client.put_bucket_cors(
         bucket: CHF::CreateDziService.bucket_name,
@@ -243,18 +255,7 @@ namespace :chf do
 
       client.put_bucket_policy(
         bucket: CHF::CreateDziService.bucket_name,
-        policy: {
-          "Version":"2012-10-17",
-          "Statement":[
-          {
-            "Sid":"AddPerm",
-            "Effect":"Allow",
-            "Principal": "*",
-            "Action":["s3:GetObject"],
-            "Resource":["arn:aws:s3:::#{CHF::CreateDziService.bucket_name}/*"]
-          }
-        ]    
-      } 
+        policy: dzi_policy 
     )
     end
 

--- a/lib/tasks/chf_tasks.rake
+++ b/lib/tasks/chf_tasks.rake
@@ -251,7 +251,7 @@ namespace :chf do
             "Effect":"Allow",
             "Principal": "*",
             "Action":["s3:GetObject"],
-            "Resource":["arn:aws:s3:::" + CHF::CreateDziService.bucket_name + "/*"]
+            "Resource":["arn:aws:s3:::#{CHF::CreateDziService.bucket_name}/*"]
           }
         ]    
       } 

--- a/lib/tasks/chf_tasks.rake
+++ b/lib/tasks/chf_tasks.rake
@@ -240,10 +240,22 @@ namespace :chf do
         }
       )
 
-      client.put_bucket_acl(
-        acl: CHF::CreateDziService.acl,
+
+      client.put_bucket_policy(
         bucket: CHF::CreateDziService.bucket_name,
-      )
+        policy: {
+          "Version":"2012-10-17",
+          "Statement":[
+          {
+            "Sid":"AddPerm",
+            "Effect":"Allow",
+            "Principal": "*",
+            "Action":["s3:GetObject"],
+            "Resource":["arn:aws:s3:::" + CHF::CreateDziService.bucket_name + "/*"]
+          }
+        ]    
+      } 
+    )
     end
 
     desc "ensure s3 acl set properly on all objects"


### PR DESCRIPTION
Applies a read permission to all objects in the dzi bucket. Means that the permission for access is now at the bucket level if we need to copy items between buckets, which causes a loss of ACLs, or any other edits that might cause an object to lose the ACL for access.

Bucket policy was taken from the AWS default example for universal read access.