### PR TITLE
enforce access-hiding on show page, without trigger solr n+1

### DIFF
--- a/app/presenters/curation_concerns/generic_work_show_presenter.rb
+++ b/app/presenters/curation_concerns/generic_work_show_presenter.rb
@@ -97,9 +97,7 @@ module CurationConcerns
     # Memoized -- building member_presenters can be expensive and we
     # call multiple times in our views, important to cache.
     def viewable_member_presenters
-      @viewable_member_presenters ||= member_presenters.find_all do |presenter|
-        current_ability.can?(:read, presenter.id)
-      end
+      @viewable_member_presenters ||= member_presenter_factory.permitted_member_presenters(action: :read)
     end
 
     # viewable_member_presenters, but if our representative image is the FIRST image,

--- a/spec/views/curation_concerns/base/show.html.erb_spec.rb
+++ b/spec/views/curation_concerns/base/show.html.erb_spec.rb
@@ -57,7 +57,7 @@ describe 'curation_concerns/base/show.html.erb' do
 
   # ability uses a non-persisted user as a null object, e.g. guest user
   let(:user) { FactoryGirl.build(:user) }
-  let(:ability) { double }
+  let(:ability) { Ability.new(user) }
   let(:presenter) do
     CurationConcerns::GenericWorkShowPresenter.new(solr_document, ability).tap do |presenter|
       # our presenter needs a view_context now, custom CHF, so it can run BL presenters too.
@@ -89,7 +89,6 @@ describe 'curation_concerns/base/show.html.erb' do
   before do
     allow(view).to receive(:search_state).and_return( Blacklight::SearchState.new({}, CatalogController.blacklight_config)  )
     allow(view).to receive(:current_ability).and_return(ability)
-    allow(ability).to receive(:current_user).and_return(user)
     stub_template 'curation_concerns/base/_relationships.html.erb' => ''
     stub_template 'curation_concerns/base/_show_actions.html.erb' => ''
     stub_template 'curation_concerns/base/_representative_media.html.erb' => ''


### PR DESCRIPTION
previous version was doing a solr request for every single member, to get it's access control info :(