### PR TITLE
Dynamic robots.txt, disallowing all in non-production

### DIFF
--- a/app/models/chf/env.rb
+++ b/app/models/chf/env.rb
@@ -142,7 +142,11 @@ module CHF
     end
 
     def self.staging?
-      ["stage", "staging"].include?(lookup(:service_level))
+      @staging ||= ["stage", "staging"].include?(lookup(:service_level))
+    end
+
+    def self.production?
+      @production ||= ["prod", "production"].include?(lookup(:service_level))
     end
 
     ######

--- a/app/views/application/robots.txt.erb
+++ b/app/views/application/robots.txt.erb
@@ -1,0 +1,14 @@
+# See http://www.robotstxt.org/robotstxt.html for documentation on how to use the robots.txt file
+#
+#
+<% if CHF::Env.production? %>
+# production robots.txt
+User-agent: *
+Crawl-delay: 5
+
+<% else %>
+# non-production robots.txt
+User-agent: *
+Disallow: /
+
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,9 @@ Rails.application.routes.draw do
   end
 
   constraints ->(request) { CHF::Env.lookup(:serve_app_paths) } do
+    # this will fall through to ./views/application/robots.txt.erb, no need for an action method
+    get 'robots.txt', to: "application#robots.txt", format: "text"
+
     # override sufia's about routing to use a static page instead of a content block
     get 'about', controller: 'static', action: 'about', as: 'about'
     # add a policy page

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,7 +1,0 @@
-# See http://www.robotstxt.org/robotstxt.html for documentation on how to use the robots.txt file
-#
-# To ban all spiders from the entire site uncomment the next two lines:
-# User-agent: *
-# Disallow: /
-User-agent: *
-Crawl-delay: 5


### PR DESCRIPTION
Closes #865

Note crawl-delay is still a high 5 as it was previously, not sure if we really need that,
might help to lower it to get indexed, but not doing it now. We have no docs of
the crawl-delay decision, if we really needed it at one point or not.