### PR TITLE
Use child work as representative presenter on show page

### DIFF
--- a/app/presenters/curation_concerns/generic_work_show_presenter.rb
+++ b/app/presenters/curation_concerns/generic_work_show_presenter.rb
@@ -91,6 +91,13 @@ module CurationConcerns
       solr_document.visibility != Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
     end
 
+    # If it's a child work, return the child work, don't go further to fileset. Gives
+    # us better for what we need in current customized app on show page.
+    def direct_representative_presenter
+      return nil if representative_id.blank?
+      @direct_representative_presenter ||= member_presenters([representative_id]).first
+    end
+
     # Like member_presenters without args, but filters to only those current
     # user has permissions to see. Used on our show page and viewer.
     #

--- a/app/views/curation_concerns/base/_show_page_image.html.erb
+++ b/app/views/curation_concerns/base/_show_page_image.html.erb
@@ -36,7 +36,7 @@
   <div class="show-page-image-bar">
     <%# this used to check for '&& can?(:read, member.id)', but that was kind of expensive,
         and in our app if you can see it you can download %>
-    <% if member.model_name.singular.to_sym == :file_set %>
+    <% if local_assigns[:size].to_s == "large" || member.model_name.singular.to_sym == :file_set %>
       <div class="btn-group dropup">
         <button type="button" class="btn btn-brand-alt dropdown-toggle" id="dropdownMenu_downloads_<%= member.id %>" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
           <%# less space for admin, just use icon %>

--- a/app/views/curation_concerns/base/show.html.erb
+++ b/app/views/curation_concerns/base/show.html.erb
@@ -51,7 +51,7 @@
   </div>
 
   <div class="show-representative">
-      <% if representative_presenter = @presenter.representative_presenter %>
+      <% if representative_presenter = @presenter.respond_to?(:direct_representative_presenter) ? @presenter.direct_representative_presenter : @presenter.representative_presenter %>
         <%= render 'show_page_image', member: representative_presenter, size: :large %>
       <% else %>
         <%= image_tag default_image(member: @presenter) %>


### PR DESCRIPTION
Not it's ultimate representative fileset. Our architectural changes mean it can already handle
this just fine. It allows us to provide the 'info' button for child work even in representative
position, while still providing download button for actual fileset (when in representative position).

All this is getting convoluted, it's hard to figure out UI for generic child work situation.

Closes #897