### PR TITLE
fix social media bug

### DIFF
--- a/app/controllers/curation_concerns/file_sets_controller_override.rb
+++ b/app/controllers/curation_concerns/file_sets_controller_override.rb
@@ -1,0 +1,2 @@
+CurationConcerns::FileSetsController.show_presenter = CHF::FileSetPresenter
+

--- a/app/views/curation_concerns/file_sets/_show_actions.html.erb
+++ b/app/views/curation_concerns/file_sets/_show_actions.html.erb
@@ -15,7 +15,5 @@
                   curation_concerns.generate_download_single_use_link_path(@presenter),
                   class: 'btn btn-default generate-single-use-link' %>
   <% end %>
-
-  <%= render 'social_media' %>
 </div>
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -101,6 +101,7 @@ module Chufia
 
     config.file_creators = [
       'Brown, Will',
+      'Conservation Center for Art & Historic Artifacts',
       'DiMeo, Michelle',
       'George Blood Audio LP',
       'Kativa, Hillary',


### PR DESCRIPTION
_social_media partial was being rendered on file set page, and then expecting our custom filesetpresenter. 
we fix in two ways: make sure our custom fileset presenter is used in FileSetsController, but also stop
rendering social media buttons on file set page, they don't work right anyway, we don't need them there.