### PR TITLE
comment out citation links for now

### DIFF
--- a/app/views/curation_concerns/base/show.html.erb
+++ b/app/views/curation_concerns/base/show.html.erb
@@ -178,8 +178,9 @@
     <% end %>
 
 
-    <hr class="brand">
-    <%= render 'citations', presenter: @presenter %>
+    <%# no citation links, the defaults aren't working well and we haven't
+        had time to make them better yet %>
+    <%# render 'citations', presenter: @presenter %>
   </div>
 
 


### PR DESCRIPTION
The original defaults don't work well, and we haven't yet had time to make better.